### PR TITLE
Fixed font install path

### DIFF
--- a/Makefile.dji
+++ b/Makefile.dji
@@ -47,7 +47,8 @@ goggle_ipk: osd_dji
 	cp -r ipk/goggle/control ipk/goggle/build/
 	cp osd_dji ipk/goggle/build/data/opt/bin
 	chmod +x ipk/goggle/build/data/opt/bin/osd_dji
-	cp font.bin ipk/goggle/build/data/opt/fonts
+	mkdir -p ipk/goggle/build/data/opt/fonts
+	cp font.bin ipk/goggle/build/data/opt/fonts/
 	cd ipk/goggle/build/control && tar czvf ../control.tar.gz .
 	cd ipk/goggle/build/data && tar czvf ../data.tar.gz .
 	cd ipk/goggle/build && tar czvf "../../${IPK_NAME}" ./control.tar.gz ./data.tar.gz ./debian-binary

--- a/ipk/goggle/control/control
+++ b/ipk/goggle/control/control
@@ -1,5 +1,5 @@
 Package: msp-osd-goggles
-Version: 0.1.0
+Version: 0.1.1
 Maintainer: bri3d
 Description: MSP OSD service for the DJI HD FPV goggles.
 Architecture: armv7-3.2

--- a/ipk/goggle/control/preinst
+++ b/ipk/goggle/control/preinst
@@ -1,0 +1,5 @@
+#!/system/bin/sh
+if [[ -f /opt/etc/fonts ]]; then
+    rm -f /opt/etc/fonts
+fi
+/opt/sbin/dinitctl -u disable msp-osd-goggles || true

--- a/ipk/goggle/control/preinst
+++ b/ipk/goggle/control/preinst
@@ -1,5 +1,5 @@
 #!/system/bin/sh
-if [[ -f /opt/etc/fonts ]]; then
-    rm -f /opt/etc/fonts
+if [[ -f /opt/fonts ]]; then
+    rm -f /opt/fonts
 fi
 /opt/sbin/dinitctl -u disable msp-osd-goggles || true


### PR DESCRIPTION
Fixed broken font install path and added preinst to clean up previous mess.

Had font.bin present in /blackbox/ while testing, sorry.

Went ahead and bumped goggles ipk version as well.