### PR TITLE
Doublebacktap to cycle back to dji osd + then back to msp-osd

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Eg.: If the Betaflight Configurator says your DJI VTx is attached to UART2, the 
 
 For betaflight - ensure you set the Video Format to PAL or Auto in the OSD tab - otherwise you don't get access to the whole OSD area.
 
-On *iNav*, this is done by selecting "HDZero VTx" as the Peripheral. Also select "HD" in the OSD tab. If the iNav OSD appears garbled at first, try entering the iNav menus using the RC sticks, and then exiting the menus. This will force iNav to switch into HD mode a second time. 
+On *iNav*, this is done by selecting "HDZero VTx" as the Peripheral. Also select "HD" in the OSD tab. If the iNav OSD appears garbled at first, try entering the iNav menus using the RC sticks, and then exiting the menus. This will force iNav to switch into HD mode a second time.
 
 On *Ardupilot*, this is done by setting:
 
@@ -51,13 +51,13 @@ and optionally
 * Rename the files for your desired font to `font` - so you should have four files: `font.bin, font_2.bin, font_hd.bin, font_hd_2.bin` .
 * Place these four files on the root of your Goggles SD card.
 * Unplug USB, if connected.
-* Restart `msp-osd` by cycling to the DJI OSD and back using the BACK button. 
+* Restart `msp-osd` by cycling to the DJI OSD and back using the BACK button.
 
 ### Generate your own Font (advanced)
 
 * Download [mcm2img](https://github.com/bri3d/mcm2img) and set up a working Python environment to run it.
 
-* Locate the font you'd like to install - it will be a `.mcm` file, in the source code repository or configurator for your Flight Controller. 
+* Locate the font you'd like to install - it will be a `.mcm` file, in the source code repository or configurator for your Flight Controller.
 
 * For Betaflight: https://github.com/betaflight/betaflight-configurator/tree/master/resources/osd/2
 * For iNav: https://github.com/iNavFlight/inav-configurator/blob/master/resources/osd/
@@ -86,7 +86,7 @@ See above - `dji_glasses` has three primary purposes:
 
 Without `dji_glasses` running we will have to replicate these functionalities.
 
-Additionally, you will need to switch back to DJI glasses in order for channel/bitrate settings to be applied after power cycling the air side (IE: between every battery) + then restart MSP-OSD again.
+Additionally, you will need to switch back to DJI glasses in order for channel/bitrate settings to be applied after power cycling the air side (IE: between every battery) + then restart MSP-OSD again. To make this easier, a double tap of the back button will trigger a return to the DJI UI, a brief pause to let it do it's thing and then return you to MSP-OSD.
 
 ### How do I create a new font (for iNav, Ardupilot, etc.)?
 
@@ -98,7 +98,7 @@ python3 mcm2img.py mcmfile.mcm font.bin RGBA
 
 ### Why is everything so big / can I make the text smaller (betaflight)?
 
-Betaflight does not support HD OSD. So you have the same 30 * 16 grid as analog uses. The field of view in the DJI goggles makes this look big. 
+Betaflight does not support HD OSD. So you have the same 30 * 16 grid as analog uses. The field of view in the DJI goggles makes this look big.
 
 You can swap to a different font to make the characters smaller, but the grid spacing is the same.
 

--- a/libshims/duml_hal.c
+++ b/libshims/duml_hal.c
@@ -1,4 +1,4 @@
-#include "src/hw/duml_hal.h"
+#include "../src/hw/duml_hal.h"
 
 duss_result_t duss_hal_initialize(duss_hal_device_desc_t *)
 {

--- a/src/osd_dji_udp.c
+++ b/src/osd_dji_udp.c
@@ -48,7 +48,7 @@
 
 #define BACK_BUTTON_DELAY 4
 #define BACK_BUTTON_DOUBLETAP_TIME 2
-#define CYCLE_SLEEP_TIME 6`
+#define CYCLE_SLEEP_TIME 9
 
 #ifdef DEBUG
 #define DEBUG_PRINT(fmt, args...)    fprintf(stderr, fmt, ## args)


### PR DESCRIPTION
Use case is when you've power cycled the air side, between packs being my motivation for adding it. 
Double tap the back button and it will then switch back to DJI, wait a bit, which allows 50mb etc to kick in, and then it reloads msp-osd. 

Delay is 9 seconds - I found 7 mostly worked + 8 to be reliable in testing; but wanted a bit of margin.

Does nothing when msp-osd not active - so doesn't affect rapid back tapping in the menu.

Tested on goggles v2 / caddx vista / betaflight