### PR TITLE
Fix SD character width

### DIFF
--- a/jni/osd_dji_overlay_udp.c
+++ b/jni/osd_dji_overlay_udp.c
@@ -109,7 +109,7 @@ struct timespec last_render;
 static char current_fc_variant[5];
 
 static display_info_t sd_display_info = {
-    .char_width = 31,
+    .char_width = 30,
     .char_height = 15,
     .font_width = 36,
     .font_height = 54,


### PR DESCRIPTION
Seems it's actually 30 wide!

https://github.com/betaflight/betaflight/blob/master/src/main/osd/osd.h#L48
```c
#define OSD_CAMERA_FRAME_MAX_WIDTH  30    // Characters per row supportes by MAX7456
```

Mainly, it's an issue for the OSD overlay renderer because it uses this to chop out the active area and center it. So with the current values out of the OSD files, everything's shifted left one tile. It's not been a problem in the goggles since the x/y offset takes care of it.

It's also high comedy because it means the THREE TILE WIDE crosshair is totally uncenterable and always has been, even for analog.