### PR TITLE
Playback OSD files in DVR

### DIFF
--- a/config/goggles/config.json
+++ b/config/goggles/config.json
@@ -9,5 +9,6 @@
     "fakehd_layout_debug": false,
     "fakehd_columns": "S",
     "fakehd_rows": "WWWWWWCCWWWWWWWD",
-    "rec_enabled": false
+    "rec_enabled": false,
+    "rec_pb_enabled": false
 }

--- a/config/goggles/schema.json
+++ b/config/goggles/schema.json
@@ -58,8 +58,8 @@
 			"widget": "checkbox"
 		},
 		"hide_diagnostics": {
-				"name": "Hide diagnostic information",
-				"widget": "checkbox"
+			"name": "Hide diagnostic information",
+			"widget": "checkbox"
 		}
 	},
 	"units": [

--- a/config/goggles/schema.json
+++ b/config/goggles/schema.json
@@ -53,10 +53,14 @@
 			"name": "Enable OSD recording",
 			"widget": "checkbox"
 		},
-        "hide_diagnostics": {
-            "name": "Hide diagnostic information",
-            "widget": "checkbox"
-        }
+		"rec_pb_enabled": {
+			"name": "Enable OSD playback",
+			"widget": "checkbox"
+		},
+		"hide_diagnostics": {
+				"name": "Hide diagnostic information",
+				"widget": "checkbox"
+		}
 	},
 	"units": [
 		"msp-osd-goggles"

--- a/config/goggles/schemaV2.json
+++ b/config/goggles/schemaV2.json
@@ -32,6 +32,15 @@
                 false
             ]
         },
+        "rec_pb_enabled": {
+            "type": "boolean",
+            "title": "Enable OSD playback",
+            "description": "",
+            "enum": [
+                true,
+                false
+            ]
+        },
         "hide_diagnostics": {
             "type": "boolean",
             "title": "Hide diagnostic information",

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -21,15 +21,17 @@ LOCAL_SRC_FILES := \
 	hw/dji_services.c \
 	json/osd_config.c \
 	json/parson.c \
+	lz4/lz4.c \
 	msp/msp_displayport.c \
 	msp/msp.c \
 	net/network.c \
 	osd_dji_overlay_udp.c \
+	rec/rec_pb.c \
 	rec/rec_shim.c \
+	rec/rec_util.c \
 	rec/rec.c \
-	util/fs_util.c \
 	toast/toast.c \
-	lz4/lz4.c
+	util/fs_util.c
 include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)

--- a/jni/osd_dji_overlay_udp.c
+++ b/jni/osd_dji_overlay_udp.c
@@ -760,12 +760,17 @@ static void rec_pb_timeout_hook()
             is_hd,
             rec_config->font_variant);
 
+        // TODO: Sketchy swap here?
+        // Might end playback after swapping channel, maybe? So back on live channel but with
+        // DISPLAY_DISABLED which would be bad. :(
         current_display_info = osd_display_info;
+        clear_overlay();
         display_mode = DISPLAY_RUNNING;
 
         rec_pb_play_loop();
 
         current_display_info = &sd_display_info;
+        memset(msp_character_map, 0, sizeof(msp_character_map));
         display_mode = DISPLAY_DISABLED;
 
         free(osd_display_info->font_page_1);

--- a/jni/osd_dji_overlay_udp.c
+++ b/jni/osd_dji_overlay_udp.c
@@ -710,13 +710,6 @@ static void rec_pb_play_loop()
     }
 
     rec_pb_stop();
-
-    free(current_display_info->font_page_1);
-    free(current_display_info->font_page_2);
-    free(current_display_info);
-
-    current_display_info = &sd_display_info;
-    display_mode = DISPLAY_DISABLED;
 }
 
 static void rec_pb_timeout_hook()
@@ -728,7 +721,9 @@ static void rec_pb_timeout_hook()
         if (rec_pb_start() == 0)
         {
             rec_config_t *rec_config = rec_pb_get_config();
+
             display_info_t *osd_display_info = malloc(sizeof(display_info_t));
+            memset(osd_display_info, 0, sizeof(display_info_t));
 
             osd_display_info->char_width = rec_config->char_width;
             osd_display_info->char_height = rec_config->char_height;
@@ -761,7 +756,15 @@ static void rec_pb_timeout_hook()
             current_display_info = osd_display_info;
 
             display_mode = DISPLAY_RUNNING;
+
             rec_pb_play_loop();
+
+            current_display_info = &sd_display_info;
+            display_mode = DISPLAY_DISABLED;
+
+            free(osd_display_info->font_page_1);
+            free(osd_display_info->font_page_2);
+            free(osd_display_info);
         }
         else
         {

--- a/jni/osd_dji_overlay_udp.c
+++ b/jni/osd_dji_overlay_udp.c
@@ -693,7 +693,7 @@ static void rec_pb_play_loop()
 
         if (diff_ns >= next_diff)
         {
-            rec_pb_get_next_frame(diff_ns, msp_character_map);
+            rec_pb_get_next_frame(diff_ns, (uint16_t *) msp_character_map);
             render_screen();
 
             clock_gettime(CLOCK_MONOTONIC, &now);

--- a/jni/osd_dji_overlay_udp.c
+++ b/jni/osd_dji_overlay_udp.c
@@ -681,25 +681,21 @@ static void rec_pb_play_loop()
     struct timespec last;
     clock_gettime(CLOCK_MONOTONIC, &last);
 
-    int64_t target_diff = NSEC_PER_SEC / 15;
+    int64_t target_diff = NSEC_PER_SEC / 15; // 15 fps
     int64_t next_diff = target_diff;
 
     while (rec_pb_gls_is_playing())
     {
-        struct timespec now, diff;
+        struct timespec now;
         clock_gettime(CLOCK_MONOTONIC, &now);
-        timespec_subtract(&diff, &now, &last);
-        int64_t diff_ns = diff.tv_sec * 1000000000 + diff.tv_nsec;
+        int64_t diff_ns = timespec_subtract_ns(&now, &last);
 
         if (diff_ns >= next_diff)
         {
-            rec_pb_get_next_frame(diff_ns, (uint16_t *) msp_character_map);
+            rec_pb_do_next_frame(diff_ns, (uint16_t *) msp_character_map);
             render_screen();
 
-            clock_gettime(CLOCK_MONOTONIC, &now);
-            timespec_subtract(&diff, &now, &last);
             last = now;
-
             next_diff = target_diff + (target_diff - diff_ns);
         }
     }

--- a/jni/osd_dji_overlay_udp.c
+++ b/jni/osd_dji_overlay_udp.c
@@ -732,25 +732,27 @@ static void rec_pb_timeout_hook()
             osd_display_info->x_offset = rec_config->x_offset;
             osd_display_info->y_offset = rec_config->y_offset;
 
-            DEBUG_PRINT("msd_osd: playback config, char_width: %d\n", osd_display_info->char_width);
-            DEBUG_PRINT("msd_osd: playback config, char_height: %d\n", osd_display_info->char_height);
-            DEBUG_PRINT("msd_osd: playback config, font_width: %d\n", osd_display_info->font_width);
-            DEBUG_PRINT("msd_osd: playback config, font_height: %d\n", osd_display_info->font_height);
-            DEBUG_PRINT("msd_osd: playback config, x_offset: %d\n", osd_display_info->x_offset);
-            DEBUG_PRINT("msd_osd: playback config, y_offset: %d\n", osd_display_info->y_offset);
+            DEBUG_PRINT("msp_osd: playback config, char_width: %d\n", osd_display_info->char_width);
+            DEBUG_PRINT("msp_osd: playback config, char_height: %d\n", osd_display_info->char_height);
+            DEBUG_PRINT("msp_osd: playback config, font_width: %d\n", osd_display_info->font_width);
+            DEBUG_PRINT("msp_osd: playback config, font_height: %d\n", osd_display_info->font_height);
+            DEBUG_PRINT("msp_osd: playback config, x_offset: %d\n", osd_display_info->x_offset);
+            DEBUG_PRINT("msp_osd: playback config, y_offset: %d\n", osd_display_info->y_offset);
 
             DEBUG_PRINT("msp_osd: gls playing dvr, loading font variant %d\n", rec_config->font_variant);
+
+            uint8_t is_hd = osd_display_info->font_width != sd_display_info.font_width;
 
             load_font(
                 &osd_display_info->font_page_1,
                 0,
-                sd_display_info.font_width != osd_display_info->font_width,
+                is_hd,
                 rec_config->font_variant);
 
             load_font(
-                &osd_display_info->font_page_1,
+                &osd_display_info->font_page_2,
                 1,
-                sd_display_info.font_width != osd_display_info->font_width,
+                is_hd,
                 rec_config->font_variant);
 
             current_display_info = osd_display_info;

--- a/jni/osd_dji_overlay_udp.c
+++ b/jni/osd_dji_overlay_udp.c
@@ -795,6 +795,7 @@ void osd_directfb(duss_disp_instance_handle_t *disp, duss_hal_obj_handle_t ion_h
     toast_load_config();
     load_fakehd_config();
     rec_load_config();
+    rec_pb_load_config();
     check_is_au_overlay_enabled();
 
     uint8_t is_v2_goggles = dji_goggles_are_v2();
@@ -919,7 +920,9 @@ void osd_directfb(duss_disp_instance_handle_t *disp, duss_hal_obj_handle_t ion_h
             render_screen();
         }
 
-        rec_pb_timeout_hook();
+        if (rec_pb_is_enabled()) {
+            rec_pb_timeout_hook();
+        }
     }
 
     free(display_driver);

--- a/jni/osd_dji_overlay_udp.c
+++ b/jni/osd_dji_overlay_udp.c
@@ -692,11 +692,11 @@ static void rec_pb_play_loop()
 
         if (diff_ns >= next_diff)
         {
-            rec_pb_do_next_frame(diff_ns, (uint16_t *) msp_character_map);
+            rec_pb_do_next_frame((uint16_t *) msp_character_map);
             render_screen();
 
-            last = now;
             next_diff = target_diff + (target_diff - diff_ns);
+            last = now;
         }
     }
 

--- a/jni/osd_dji_overlay_udp.c
+++ b/jni/osd_dji_overlay_udp.c
@@ -681,7 +681,7 @@ static void rec_pb_play_loop()
     struct timespec last;
     clock_gettime(CLOCK_MONOTONIC, &last);
 
-    int64_t target_diff = 16666666 * 2;
+    int64_t target_diff = NSEC_PER_SEC / 15;
     int64_t next_diff = target_diff;
 
     while (rec_pb_gls_is_playing())
@@ -689,22 +689,17 @@ static void rec_pb_play_loop()
         struct timespec now, diff;
         clock_gettime(CLOCK_MONOTONIC, &now);
         timespec_subtract(&diff, &now, &last);
-        int64_t diff_ns = diff.tv_nsec;
+        int64_t diff_ns = diff.tv_sec * 1000000000 + diff.tv_nsec;
 
         if (diff_ns >= next_diff)
         {
-
-            if (rec_pb_get_next_frame(diff_ns, msp_character_map) != 0) {
-                break;
-            }
-
+            rec_pb_get_next_frame(diff_ns, msp_character_map);
             render_screen();
 
             clock_gettime(CLOCK_MONOTONIC, &now);
             timespec_subtract(&diff, &now, &last);
             last = now;
 
-            int64_t diff_ns = diff.tv_sec * 1000000000 + diff.tv_nsec;
             next_diff = target_diff + (target_diff - diff_ns);
         }
     }
@@ -869,7 +864,7 @@ void osd_directfb(duss_disp_instance_handle_t *disp, duss_hal_obj_handle_t ion_h
         poll_fds[3].events = POLLIN;
 
         // spin every 250ms if we didn't get a packet, then check and see if we need to do the toast/overlay logic
-        int poll_status = poll(poll_fds, 4, 250);
+        poll(poll_fds, 4, 250);
 
         clock_gettime(CLOCK_MONOTONIC, &now);
 
@@ -929,9 +924,7 @@ void osd_directfb(duss_disp_instance_handle_t *disp, duss_hal_obj_handle_t ion_h
             render_screen();
         }
 
-        if (poll_status == 0) {
-            rec_pb_timeout_hook();
-        }
+        rec_pb_timeout_hook();
     }
 
     free(display_driver);

--- a/jni/osd_dji_overlay_udp.c
+++ b/jni/osd_dji_overlay_udp.c
@@ -714,8 +714,18 @@ static void rec_pb_play_loop()
 
 static void rec_pb_timeout_hook()
 {
-    if (rec_pb_gls_is_playing() == true)
-    {
+    uint8_t is_playing = rec_pb_gls_is_playing();
+
+    // Only try start once per playback.
+    if (is_playing == true && rec_pb_start_attempted == true) {
+        return;
+    } else if (is_playing == true) {
+        rec_pb_start_attempted = true;
+    } else {
+        rec_pb_start_attempted = false;
+    }
+
+    if (is_playing == true) {
         DEBUG_PRINT("msp_osd: gls playing dvr, let's try too!\n");
 
         if (rec_pb_start() == 0)
@@ -756,7 +766,6 @@ static void rec_pb_timeout_hook()
                 rec_config->font_variant);
 
             current_display_info = osd_display_info;
-
             display_mode = DISPLAY_RUNNING;
 
             rec_pb_play_loop();

--- a/jni/osd_dji_overlay_udp.c
+++ b/jni/osd_dji_overlay_udp.c
@@ -176,35 +176,6 @@ static void msp_draw_character(uint32_t x, uint32_t y, uint16_t c) {
     draw_character(current_display_info, msp_character_map, x, y, c);
 }
 
-/* Recording hooks */
-
-void rec_msp_draw_complete_hook()
-{
-    if (rec_is_osd_recording() == false && rec_is_gls_recording() == true)
-    {
-        if (current_fc_variant[0] == '\0')
-        {
-            DEBUG_PRINT("msp_osd: gls started recording, but no fc variant yet!?\n");
-            return;
-        }
-
-        DEBUG_PRINT("msp_osd: gls started recording, start osd rec\n");
-
-        rec_start_config_t config = {
-            .frame_width = current_display_info->char_width,
-            .frame_height = current_display_info->char_height,
-            .font_variant = font_variant_from_string(current_fc_variant),
-        };
-
-        rec_start(&config);
-    }
-    else if (rec_is_osd_recording() == true && rec_is_gls_recording() == false)
-    {
-        DEBUG_PRINT("msp_osd: gls stopped recording, stop osd rec\n");
-        rec_stop();
-    }
-}
-
 /* Main rendering function: take a character_map and a display_info and draw it into a framebuffer */
 
 static void draw_character_map(display_info_t *display_info, void* restrict fb_addr, uint16_t character_map[MAX_DISPLAY_X][MAX_DISPLAY_Y]) {

--- a/jni/osd_dji_overlay_udp.c
+++ b/jni/osd_dji_overlay_udp.c
@@ -723,59 +723,54 @@ static void rec_pb_timeout_hook()
     if (is_playing == true) {
         DEBUG_PRINT("msp_osd: gls playing dvr, let's try too!\n");
 
-        if (rec_pb_start() == 0)
+        if (rec_pb_start() != 0)
         {
-            rec_config_t *rec_config = rec_pb_get_config();
-
-            display_info_t *osd_display_info = malloc(sizeof(display_info_t));
-            memset(osd_display_info, 0, sizeof(display_info_t));
-
-            osd_display_info->char_width = rec_config->char_width;
-            osd_display_info->char_height = rec_config->char_height;
-            osd_display_info->font_width = rec_config->font_width;
-            osd_display_info->font_height = rec_config->font_height;
-            osd_display_info->x_offset = rec_config->x_offset;
-            osd_display_info->y_offset = rec_config->y_offset;
-
-            DEBUG_PRINT("msp_osd: playback config, char_width: %d\n", osd_display_info->char_width);
-            DEBUG_PRINT("msp_osd: playback config, char_height: %d\n", osd_display_info->char_height);
-            DEBUG_PRINT("msp_osd: playback config, font_width: %d\n", osd_display_info->font_width);
-            DEBUG_PRINT("msp_osd: playback config, font_height: %d\n", osd_display_info->font_height);
-            DEBUG_PRINT("msp_osd: playback config, x_offset: %d\n", osd_display_info->x_offset);
-            DEBUG_PRINT("msp_osd: playback config, y_offset: %d\n", osd_display_info->y_offset);
-
-            DEBUG_PRINT("msp_osd: gls playing dvr, loading font variant %d\n", rec_config->font_variant);
-
-            uint8_t is_hd = osd_display_info->font_width != sd_display_info.font_width;
-
-            load_font(
-                &osd_display_info->font_page_1,
-                0,
-                is_hd,
-                rec_config->font_variant);
-
-            load_font(
-                &osd_display_info->font_page_2,
-                1,
-                is_hd,
-                rec_config->font_variant);
-
-            current_display_info = osd_display_info;
-            display_mode = DISPLAY_RUNNING;
-
-            rec_pb_play_loop();
-
-            current_display_info = &sd_display_info;
-            display_mode = DISPLAY_DISABLED;
-
-            free(osd_display_info->font_page_1);
-            free(osd_display_info->font_page_2);
-            free(osd_display_info);
+            DEBUG_PRINT("msp_osd: failed to start playback!\n");
+            return;
         }
-        else
-        {
-            DEBUG_PRINT("msp_osd: failed to init rec_pb\n");
-        }
+
+        rec_config_t *rec_config = rec_pb_get_config();
+        display_info_t *osd_display_info = malloc(sizeof(display_info_t));
+        memset(osd_display_info, 0, sizeof(display_info_t));
+
+        osd_display_info->char_width = rec_config->char_width;
+        osd_display_info->char_height = rec_config->char_height;
+        osd_display_info->font_width = rec_config->font_width;
+        osd_display_info->font_height = rec_config->font_height;
+        osd_display_info->x_offset = rec_config->x_offset;
+        osd_display_info->y_offset = rec_config->y_offset;
+
+        DEBUG_PRINT("msp_osd: playback config, char_width: %d\n", osd_display_info->char_width);
+        DEBUG_PRINT("msp_osd: playback config, char_height: %d\n", osd_display_info->char_height);
+        DEBUG_PRINT("msp_osd: playback config, font_width: %d\n", osd_display_info->font_width);
+        DEBUG_PRINT("msp_osd: playback config, font_height: %d\n", osd_display_info->font_height);
+        DEBUG_PRINT("msp_osd: playback config, x_offset: %d\n", osd_display_info->x_offset);
+        DEBUG_PRINT("msp_osd: playback config, y_offset: %d\n", osd_display_info->y_offset);
+
+        DEBUG_PRINT("msp_osd: gls playing dvr, loading font variant %d\n", rec_config->font_variant);
+        uint8_t is_hd = osd_display_info->font_width != sd_display_info.font_width;
+        load_font(
+            &osd_display_info->font_page_1,
+            0,
+            is_hd,
+            rec_config->font_variant);
+        load_font(
+            &osd_display_info->font_page_2,
+            1,
+            is_hd,
+            rec_config->font_variant);
+
+        current_display_info = osd_display_info;
+        display_mode = DISPLAY_RUNNING;
+
+        rec_pb_play_loop();
+
+        current_display_info = &sd_display_info;
+        display_mode = DISPLAY_DISABLED;
+
+        free(osd_display_info->font_page_1);
+        free(osd_display_info->font_page_2);
+        free(osd_display_info);
     }
 }
 

--- a/jni/osd_dji_overlay_udp.c
+++ b/jni/osd_dji_overlay_udp.c
@@ -784,7 +784,6 @@ void osd_directfb(duss_disp_instance_handle_t *disp, duss_hal_obj_handle_t ion_h
                 }
             }
         }
-
         if(poll_fds[1].revents) {
             // Got eventfd message from another thread to enable/disable OSD
             if (0 < (recv_len = read(event_fd, &event_number, sizeof(uint64_t)))) {

--- a/jni/rec/rec.c
+++ b/jni/rec/rec.c
@@ -11,7 +11,7 @@
 #define REC_CONFIG_ENABLED_KEY "rec_enabled"
 
 #ifdef DEBUG
-#define DEBUG_PRINT(fmt, args...) fprintf(stderr, "msp_osd.rec_shim: " fmt "\n", ##args)
+#define DEBUG_PRINT(fmt, args...) fprintf(stderr, "msp_osd.rec: " fmt "\n", ##args)
 #else
 #define DEBUG_PRINT(fmt, args...)
 #endif

--- a/jni/rec/rec.c
+++ b/jni/rec/rec.c
@@ -6,6 +6,7 @@
 
 #include "rec.h"
 #include "rec_shim.h"
+#include "rec_util.h"
 
 #define REC_CONFIG_ENABLED_KEY "rec_enabled"
 
@@ -14,19 +15,6 @@
 #else
 #define DEBUG_PRINT(fmt, args...)
 #endif
-
-typedef struct rec_file_header_t
-{
-    char magic[7];
-    uint16_t version;
-    rec_config_t config;
-} __attribute__((packed)) rec_file_header_t;
-
-typedef struct rec_frame_header_t
-{
-    uint32_t frame_idx;
-    uint32_t size;
-} __attribute__((packed)) rec_frame_header_t;
 
 static bool rec_is_ready();
 static uint32_t rec_get_frame_idx();
@@ -47,21 +35,11 @@ void rec_start(rec_config_t *config)
         fclose(rec_fd);
     }
 
-    char *file_basename = strrchr(rec_lv_transcode->file_name, '/') + 1;
-    char *file_ext = strrchr(file_basename, '.');
-    uint8_t file_dir_len = file_basename - rec_lv_transcode->file_name - 1;
-    uint8_t file_stem_len = file_ext - file_basename;
-
     char rec_file_name[256];
-    snprintf(
-        rec_file_name,
-        sizeof(rec_file_name),
-        "%.*s/%.*s.osd",
-        file_dir_len,
+    rec_util_osd_path_from_video_path(
         rec_lv_transcode->file_name,
-        file_stem_len,
-        file_basename);
-
+        rec_file_name,
+        sizeof(rec_file_name));
     DEBUG_PRINT("rec_file_name: %s", rec_file_name);
 
     rec_fd = fopen(rec_file_name, "wb");

--- a/jni/rec/rec.c
+++ b/jni/rec/rec.c
@@ -139,8 +139,6 @@ static bool rec_is_ready()
 
 static uint32_t rec_get_frame_idx()
 {
-    if (rec_is_ready() == false)
-        return 0;
 
     return rec_lv_transcode->last_frame_idx;
 }

--- a/jni/rec/rec.h
+++ b/jni/rec/rec.h
@@ -17,6 +17,19 @@ typedef struct rec_config_t
     uint8_t font_variant;
 } __attribute__((packed)) rec_config_t;
 
+typedef struct rec_file_header_t
+{
+    char magic[7];
+    uint16_t version;
+    rec_config_t config;
+} __attribute__((packed)) rec_file_header_t;
+
+typedef struct rec_frame_header_t
+{
+    uint32_t frame_idx;
+    uint32_t size;
+} __attribute__((packed)) rec_frame_header_t;
+
 void rec_start();
 void rec_stop();
 void rec_load_config();

--- a/jni/rec/rec_pb.c
+++ b/jni/rec/rec_pb.c
@@ -171,9 +171,8 @@ int rec_pb_get_next_frame(int64_t frame_delta, uint16_t *map_out)
 
     fseek(
         osd_fd,
-        sizeof(rec_file_header_t)
-            + (closest_frame_idx * (sizeof(rec_frame_header_t) + (sizeof(uint16_t) * MAX_T))) +
-            + sizeof(rec_frame_header_t),
+        sizeof(rec_file_header_t) + (closest_frame_idx * (sizeof(rec_frame_header_t) + (sizeof(uint16_t) * MAX_T))) +
+            +sizeof(rec_frame_header_t),
         SEEK_SET);
     fread(map_out, sizeof(uint16_t), MAX_T, osd_fd);
 

--- a/jni/rec/rec_pb.c
+++ b/jni/rec/rec_pb.c
@@ -190,7 +190,7 @@ bool rec_pb_gls_is_playing()
         return false;
     }
 
-    return rec_pb_vdec_local_player->b_running && !rec_pb_vdec_local_player->b_v_eos;
+    return rec_pb_vdec_local_player->b_running || rec_pb_vdec_local_player->b_v_eos;
 }
 
 bool rec_pb_is_ready()

--- a/jni/rec/rec_pb.c
+++ b/jni/rec/rec_pb.c
@@ -21,6 +21,7 @@
 
 cp_vdec_t *rec_pb_cp_vdec = NULL;
 vdec_local_player_t *rec_pb_vdec_local_player = NULL;
+uint8_t rec_pb_start_attempted = false;
 
 static FILE *osd_fd = NULL;
 static rec_config_t osd_config = {0};

--- a/jni/rec/rec_pb.c
+++ b/jni/rec/rec_pb.c
@@ -206,7 +206,9 @@ bool rec_pb_gls_is_playing()
         return false;
     }
 
-    return rec_pb_vdec_local_player->b_running || rec_pb_vdec_local_player->b_v_eos;
+    return rec_pb_vdec_local_player->b_running
+        && !rec_pb_vdec_local_player->b_v_eos
+        && rec_pb_vdec_local_player->state != 5; // TODO: Where's the enum for this?
 }
 
 bool rec_pb_is_ready()

--- a/jni/rec/rec_pb.c
+++ b/jni/rec/rec_pb.c
@@ -46,6 +46,7 @@ int rec_pb_start()
         return 1;
     }
 
+    // TODO: Mutex needed here? Can cause a cause if placback stops as we're trying to read info.
     DEBUG_PRINT("playback on: %s", rec_pb_vdec_local_player->fmt_ctx->filename);
 
     char osd_path[256];

--- a/jni/rec/rec_pb.c
+++ b/jni/rec/rec_pb.c
@@ -47,7 +47,7 @@ int rec_pb_start()
         return 1;
     }
 
-    // TODO: Mutex needed here? Can cause a cause if placback stops as we're trying to read info.
+    // TODO: Mutex needed here? Can cause a crash if placback stops as we're trying to read info.
     DEBUG_PRINT("playback on: %s", rec_pb_vdec_local_player->fmt_ctx->filename);
 
     char osd_path[256];

--- a/jni/rec/rec_pb.c
+++ b/jni/rec/rec_pb.c
@@ -138,12 +138,11 @@ rec_config_t *rec_pb_get_config()
 
 int rec_pb_get_next_frame(int64_t frame_delta, uint16_t *map_out)
 {
-
     uint64_t rtos_frame_counter = ((rec_pb_cp_vdec->play_tm_ms) * 60 / 1000) - 45;
 
     // play_to_ms only updates when the RTOS is fed frames (which are buffered in, in chunks)
     // so we gotta interpolate a little when it's "frozen".
-    if (last_rtos_frame_counter == rtos_frame_counter)
+    if (last_rtos_frame_counter == rtos_frame_counter && rec_pb_cp_vdec->vdec_state == VDEC_PLAYING)
     {
         uint8_t frames_since = frame_delta / 16666666;
         frame_counter += frames_since;

--- a/jni/rec/rec_pb.c
+++ b/jni/rec/rec_pb.c
@@ -3,11 +3,15 @@
 #include <string.h>
 #include <sys/ioctl.h>
 
+#include "../json/osd_config.h"
+
 #include "rec.h"
 #include "rec_shim.h"
 #include "rec_util.h"
 
 #include "rec_pb.h"
+
+#define REC_PB_CONFIG_ENABLED_KEY "rec_pb_enabled"
 
 #define MAX_X 60
 #define MAX_Y 22
@@ -23,6 +27,8 @@ cp_vdec_t *rec_pb_cp_vdec = NULL;
 vdec_local_player_t *rec_pb_vdec_local_player = NULL;
 uint8_t rec_pb_start_attempted = false;
 
+static bool rec_pb_enabled = false;
+
 static FILE *osd_fd = NULL;
 static rec_config_t osd_config = {0};
 
@@ -32,6 +38,18 @@ static int64_t last_rtos_frame_counter = 0;
 static uint32_t *frame_idxs;
 static uint32_t frame_idx_len = 0;
 static uint32_t current_frame_idx = 0;
+
+void rec_pb_load_config()
+{
+    rec_pb_enabled = get_boolean_config_value(REC_PB_CONFIG_ENABLED_KEY);
+
+    DEBUG_PRINT("rec_pb_enabled: %d", rec_pb_enabled);
+}
+
+bool rec_pb_is_enabled()
+{
+    return rec_pb_enabled;
+}
 
 int rec_pb_start()
 {

--- a/jni/rec/rec_pb.c
+++ b/jni/rec/rec_pb.c
@@ -1,0 +1,184 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+
+#include "rec.h"
+#include "rec_shim.h"
+#include "rec_util.h"
+
+#include "rec_pb.h"
+
+#define MAX_X 60
+#define MAX_Y 22
+#define MAX_T (MAX_X * MAX_Y)
+
+#ifdef DEBUG
+#define DEBUG_PRINT(fmt, args...) fprintf(stderr, "msp_osd.rec_pb: " fmt "\n", ##args)
+#else
+#define DEBUG_PRINT(fmt, args...)
+#endif
+
+cp_vdec_t *rec_pb_cp_vdec = NULL;
+vdec_local_player_t *rec_pb_vdec_local_player = NULL;
+
+static FILE *osd_fd = NULL;
+static rec_config_t osd_config = {0};
+
+static int64_t frame_counter = 0;
+static int64_t last_frame_counter = 0;
+
+static rec_frame_header_t current_frame_header = {0};
+static uint16_t current_frame_map[MAX_T] = {0};
+
+static rec_frame_header_t next_frame_header = {0};
+static uint16_t next_frame_map[MAX_T] = {0};
+
+int rec_pb_start()
+{
+    if (rec_pb_is_ready() == false)
+    {
+        return 1;
+    }
+
+    if (osd_fd != NULL)
+    {
+        return 1;
+    }
+
+    DEBUG_PRINT("playback on: %s", rec_pb_vdec_local_player->fmt_ctx->filename);
+
+    char osd_path[256];
+    rec_util_osd_path_from_video_path(rec_pb_vdec_local_player->fmt_ctx->filename, osd_path, sizeof(osd_path));
+
+    DEBUG_PRINT("osd path: %s", osd_path);
+    osd_fd = fopen(osd_path, "rb");
+    if (osd_fd == NULL)
+    {
+        DEBUG_PRINT("osd file not found");
+        return 1;
+    }
+
+    DEBUG_PRINT("osd file found");
+    rec_file_header_t file_header;
+    fread(&file_header, sizeof(rec_file_header_t), 1, osd_fd);
+
+    if (strncmp(file_header.magic, REC_MAGIC, sizeof(REC_MAGIC)) != 0)
+    {
+        DEBUG_PRINT("invalid osd file");
+        fclose(osd_fd);
+        osd_fd = NULL;
+        return 1;
+    }
+
+    if (file_header.version != REC_VERSION)
+    {
+        DEBUG_PRINT("invalid osd file version! expected: %d, got: %d", REC_VERSION, file_header.version);
+        fclose(osd_fd);
+        osd_fd = NULL;
+        return 1;
+    }
+
+    DEBUG_PRINT("header ok!");
+    memcpy(&osd_config, &file_header.config, sizeof(rec_config_t));
+
+    fread(&current_frame_header, sizeof(rec_frame_header_t), 1, osd_fd);
+    fread(&current_frame_map, sizeof(uint16_t), MAX_T, osd_fd);
+
+    fread(&next_frame_header, sizeof(rec_frame_header_t), 1, osd_fd);
+    fread(&next_frame_map, sizeof(uint16_t), MAX_T, osd_fd);
+
+    frame_counter = rec_pb_cp_vdec->frames_sent;
+
+    return 0;
+}
+
+void rec_pb_stop()
+{
+    if (osd_fd != NULL)
+    {
+        fclose(osd_fd);
+        osd_fd = NULL;
+    }
+
+    rec_pb_cp_vdec = NULL;
+    rec_pb_vdec_local_player = NULL;
+
+    DEBUG_PRINT("playback stopped");
+}
+
+rec_config_t *rec_pb_get_config()
+{
+    if (rec_pb_is_ready() == false)
+    {
+        return NULL;
+    }
+
+    return &osd_config;
+}
+
+int rec_pb_get_next_frame(int64_t frame_delta, uint16_t *map_out) {
+    // frame_counter += frame_delta / 1000 / 1000 / 1000;
+
+    // //DEBUG_PRINT("%lld", rec_pb_cp_vdec->play_tm_ms);
+
+    // frame_counter = rec_pb_cp_vdec->play_tm_ms / (1000 / 60);
+
+    last_frame_counter = frame_counter;
+    frame_counter = ((rec_pb_cp_vdec->play_tm_ms) * 60 / 1000) - 45;
+
+    if (frame_counter == last_frame_counter)
+    {
+        frame_counter += 2;
+    }
+
+    // if (llabs((int64_t)frame_counter - rec_pb_cp_vdec->frames_sent) >= 90)
+    // {
+    //     DEBUG_PRINT("sync: frame_counter: %f, frames_sent: %d", frame_counter, rec_pb_cp_vdec->frames_sent);
+    //     frame_counter = rec_pb_cp_vdec->frames_sent;
+    // }
+
+    if (frame_counter >= next_frame_header.frame_idx) {
+        current_frame_header = next_frame_header;
+        memcpy(current_frame_map, next_frame_map, sizeof(uint16_t) * MAX_T);
+        memcpy(map_out, &current_frame_map, sizeof(uint16_t) * MAX_T);
+
+        while (true) {
+            // DEBUG_PRINT("searching for next frame");
+
+            if (fread(&next_frame_header, sizeof(rec_frame_header_t), 1, osd_fd) != 1) {
+                return 1;
+            }
+
+            if (next_frame_header.frame_idx >= current_frame_header.frame_idx + 2) {
+                // DEBUG_PRINT("found frame");
+                break;
+            }
+
+            if (fseek(osd_fd, sizeof(uint16_t) * MAX_T, SEEK_CUR) != 0) {
+                return 1;
+            }
+        }
+
+        if (fread(&next_frame_map, sizeof(uint16_t), MAX_T, osd_fd) != MAX_T) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+bool rec_pb_gls_is_playing()
+{
+    if (rec_pb_is_ready() == false)
+    {
+        return false;
+    }
+
+    return rec_pb_vdec_local_player->b_running && !rec_pb_vdec_local_player->b_v_eos;
+}
+
+bool rec_pb_is_ready()
+{
+    return rec_pb_cp_vdec != NULL && rec_pb_vdec_local_player != NULL;
+}

--- a/jni/rec/rec_pb.h
+++ b/jni/rec/rec_pb.h
@@ -6,6 +6,9 @@
 
 extern uint8_t rec_pb_start_attempted;
 
+void rec_pb_load_config();
+bool rec_pb_is_enabled();
+
 int rec_pb_start();
 void rec_pb_stop();
 

--- a/jni/rec/rec_pb.h
+++ b/jni/rec/rec_pb.h
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+extern uint8_t rec_pb_start_attempted;
+
 int rec_pb_start();
 void rec_pb_stop();
 

--- a/jni/rec/rec_pb.h
+++ b/jni/rec/rec_pb.h
@@ -12,7 +12,7 @@ bool rec_pb_is_enabled();
 int rec_pb_start();
 void rec_pb_stop();
 
-int rec_pb_do_next_frame(int64_t frame_delta, uint16_t *map_out);
+int rec_pb_do_next_frame(uint16_t *map_out);
 
 rec_config_t *rec_pb_get_config();
 

--- a/jni/rec/rec_pb.h
+++ b/jni/rec/rec_pb.h
@@ -12,7 +12,7 @@ bool rec_pb_is_enabled();
 int rec_pb_start();
 void rec_pb_stop();
 
-int rec_pb_get_next_frame(int64_t frame_delta, uint16_t *map_out);
+int rec_pb_do_next_frame(int64_t frame_delta, uint16_t *map_out);
 
 rec_config_t *rec_pb_get_config();
 

--- a/jni/rec/rec_pb.h
+++ b/jni/rec/rec_pb.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+int rec_pb_start();
+void rec_pb_stop();
+
+int rec_pb_get_next_frame(int64_t frame_delta, uint16_t *map_out);
+
+rec_config_t *rec_pb_get_config();
+
+bool rec_pb_is_ready();
+bool rec_pb_gls_is_playing();

--- a/jni/rec/rec_shim.c
+++ b/jni/rec/rec_shim.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "../hw/dji_services.h"
 #include "rec_shim.h"
 
 #ifdef DEBUG
@@ -14,22 +15,45 @@ duss_osal_priority_t (*duss_osal_task_create_orig)(
     duss_osal_task_attrib_t *task_attrib,
     duss_osal_task_handle_t **task_handle) = NULL;
 
+extern cp_vdec_t *rec_pb_cp_vdec;
+extern vdec_local_player_t *rec_pb_vdec_local_player;
+
 extern gs_lv_transcode_t *rec_lv_transcode;
 
 duss_osal_priority_t duss_osal_task_create(
     duss_osal_task_attrib_t *task_attrib,
     duss_osal_task_handle_t **task_handle)
 {
-  if (duss_osal_task_create_orig == NULL)
-  {
-    duss_osal_task_create_orig = dlsym(RTLD_NEXT, "duss_osal_task_create");
-  }
+    if (duss_osal_task_create_orig == NULL)
+    {
+        duss_osal_task_create_orig = dlsym(RTLD_NEXT, "duss_osal_task_create");
+    }
 
-  if (strcmp(task_attrib->name, "record_thread") == 0)
-  {
-    rec_lv_transcode = task_attrib->param;
-    DEBUG_PRINT("got lv_transcode from record_thread: %p", rec_lv_transcode);
-  }
+    if (strcmp(task_attrib->name, "record_thread") == 0)
+    {
+        rec_lv_transcode = task_attrib->param;
+        DEBUG_PRINT("got lv_transcode_t from record_thread: %p", rec_lv_transcode);
+    }
+    else if (strcmp(task_attrib->name, "player_thread") == 0)
+    {
+        gs_info_t *ctx = task_attrib->param;
 
-  return duss_osal_task_create_orig(task_attrib, task_handle);
+        if (dji_goggles_are_v2())
+        {
+            rec_pb_vdec_local_player = *(vdec_local_player_t **)((void *)ctx + 0x8b8);
+        }
+        else
+        {
+            rec_pb_vdec_local_player = ctx->player;
+        }
+
+        DEBUG_PRINT("got vdec_local_player_t from player_thread: %p", rec_pb_vdec_local_player);
+    }
+    else if (strcmp(task_attrib->name, "vdec_thread") == 0)
+    {
+        rec_pb_cp_vdec = task_attrib->param;
+        DEBUG_PRINT("got cp_vdec_t from vdec_thread: %p", rec_pb_cp_vdec);
+    }
+
+    return duss_osal_task_create_orig(task_attrib, task_handle);
 }

--- a/jni/rec/rec_shim.h
+++ b/jni/rec/rec_shim.h
@@ -18,36 +18,291 @@ typedef unsigned int undefined4;
 typedef unsigned long long undefined8;
 typedef unsigned short ushort;
 typedef unsigned short word;
-typedef struct gs_lv_transcode gs_lv_transcode;
+typedef struct __gs_info __gs_info;
 
-typedef struct ion_info ion_info;
+typedef struct __gs_info gs_info_t;
 
-typedef struct ion_info ion_info_t;
+typedef struct duss_event_client duss_event_client;
 
-typedef struct duss_osal_mutex_handle_t duss_osal_mutex_handle_t;
+typedef struct duss_event_client *duss_event_client_handle_t;
 
-typedef enum record_state
-{
-    RECORD_STATE_IDLE = 0,
-    RECORD_STATE_RECORDING = 1,
-    RECORD_STATE_STOP_ERROR = 2,
-    RECORD_STATE_STOP_FULL = 3,
-    RECORD_STATE_STOP_WRITE_SLOW = 4,
-    RECORD_STATE_STARTING = 5,
-    RECORD_STATE_STOPPING = 6
-} record_state;
+typedef struct duss_hal_obj duss_hal_obj;
 
-typedef enum record_state record_state_t;
+typedef struct duss_hal_obj *duss_hal_obj_handle_t;
+
+typedef int __int32_t;
+
+typedef __int32_t int32_t;
+
+typedef struct gs_debug_ctrl gs_debug_ctrl;
+
+typedef struct gs_debug_ctrl gs_debug_ctrl_t;
 
 typedef struct duss_osal_task_handle_t duss_osal_task_handle_t;
+
+typedef struct __gs_local_sd_info __gs_local_sd_info;
+
+typedef struct __gs_local_sd_info gs_local_sd_info_t;
+
+typedef struct duss_osal_timer_handle_t duss_osal_timer_handle_t;
+
+typedef struct _DUSS_MSG_RC_BAT_INFO_t _DUSS_MSG_RC_BAT_INFO_t;
+
+typedef struct _DUSS_MSG_RC_BAT_INFO_t DUSS_MSG_RC_BAT_INFO_t;
+
+typedef struct gs_battery_info gs_battery_info;
+
+typedef struct gs_battery_info gs_battery_info_t;
 
 typedef uchar __uint8_t;
 
 typedef __uint8_t uint8_t;
 
-typedef struct __gs_local_sd_info __gs_local_sd_info;
+typedef struct gs_modem_ctrl gs_modem_ctrl;
 
-typedef struct __gs_local_sd_info gs_local_sd_info_t;
+typedef struct gs_modem_ctrl gs_modem_ctrl_t;
+
+typedef struct _DUSS_MSG_RC_MS_LINK_STATUS _DUSS_MSG_RC_MS_LINK_STATUS;
+
+typedef struct _DUSS_MSG_RC_MS_LINK_STATUS DUSS_MSG_RC_MS_LINK_STATUS_t;
+
+typedef struct __gs_use_times_info __gs_use_times_info;
+
+typedef struct __gs_use_times_info gs_use_times_info_t;
+
+typedef struct gs_rc_ctrl gs_rc_ctrl;
+
+typedef struct gs_rc_ctrl gs_rc_ctrl_t;
+
+typedef struct keys_pack_to_racing_glass_t keys_pack_to_racing_glass_t;
+
+typedef struct duss_osal_timer_attrib_t duss_osal_timer_attrib_t;
+
+typedef struct pack_for_factory_test_t pack_for_factory_test_t;
+
+typedef struct gs_buzzer_info gs_buzzer_info;
+
+typedef struct gs_buzzer_info gs_buzzer_info_t;
+
+typedef struct gs_fan_info gs_fan_info;
+
+typedef struct gs_fan_info gs_fan_info_t;
+
+typedef struct __gs_common_cmd_ctrl __gs_common_cmd_ctrl;
+
+typedef struct __gs_common_cmd_ctrl gs_common_cmd_ctrl_t;
+
+typedef struct gs_camera_cmd_ctrl_t gs_camera_cmd_ctrl_t;
+
+typedef struct _DUSS_MSG_CAMERA_STATUS_PUSH_t _DUSS_MSG_CAMERA_STATUS_PUSH_t;
+
+typedef struct _DUSS_MSG_CAMERA_STATUS_PUSH_t DUSS_MSG_CAMERA_STATUS_PUSH_t;
+
+typedef struct gs_video_channel_manager gs_video_channel_manager;
+
+typedef struct gs_video_channel_manager gs_video_channel_manager_t;
+
+typedef struct gs_wl_ctrl gs_wl_ctrl;
+
+typedef struct gs_wl_ctrl gs_wl_ctrl_t;
+
+typedef struct gs_av_in_ctrl gs_av_in_ctrl;
+
+typedef struct gs_av_in_ctrl gs_av_in_ctrl_t;
+
+typedef struct vdec_local_player vdec_local_player;
+
+typedef struct vdec_local_player vdec_local_player_t;
+
+typedef struct metadata_retriever metadata_retriever;
+
+typedef struct metadata_retriever metadata_retriever_t;
+
+typedef struct gs_lv_src gs_lv_src;
+
+typedef struct gs_lv_src gs_lv_src_t;
+
+typedef struct gs_lv_rec_ctrl gs_lv_rec_ctrl;
+
+typedef struct gs_lv_rec_ctrl gs_lv_rec_ctrl_t;
+
+typedef struct gs_usb_gadget_vt gs_usb_gadget_vt;
+
+typedef struct gs_usb_gadget_vt gs_usb_gadget_vt_t;
+
+typedef struct gs_lv_transcode gs_lv_transcode;
+
+typedef struct gs_lv_transcode gs_lv_transcode_t;
+
+typedef struct gs_aout gs_aout;
+
+typedef struct gs_aout gs_aout_t;
+
+typedef struct gs_audio_wl gs_audio_wl;
+
+typedef struct gs_audio_wl gs_audio_wl_t;
+
+typedef struct gs_media_cmd_chnl gs_media_cmd_chnl;
+
+typedef struct gs_media_cmd_chnl gs_media_cmd_chnl_t;
+
+typedef struct gs_bl gs_bl;
+
+typedef struct gs_bl gs_bl_t;
+
+typedef struct timeval timeval;
+
+typedef uint __uint32_t;
+
+typedef __uint32_t uint32_t;
+
+typedef struct __gs_gui __gs_gui;
+
+typedef struct __gs_gui_config __gs_gui_config;
+
+typedef struct debug_osd_info debug_osd_info;
+
+typedef struct debug_osd_info debug_codec_osd_info_t;
+
+typedef struct debug_cam_osd_info debug_cam_osd_info;
+
+typedef struct debug_cam_osd_info debug_cam_osd_info_t;
+
+typedef struct debug_temp_osd_info debug_temp_osd_info;
+
+typedef struct debug_temp_osd_info debug_temp_osd_info_t;
+
+typedef struct debug_cp_osd_info debug_cp_osd_info;
+
+typedef struct debug_cp_osd_info debug_cp_osd_info_t;
+
+typedef ulonglong __uint64_t;
+
+typedef __uint64_t uint64_t;
+
+typedef enum record_mode
+{
+    RECORD_MODE_MANNUAL = 0,
+    RECORD_MODE_LOOPING = 1
+} record_mode;
+
+typedef enum record_mode record_mode_t;
+
+typedef enum Record_sender
+{
+    RECORD_BUTTON = 0,
+    RECORD_DISARM = 1
+} Record_sender;
+
+typedef ushort __uint16_t;
+
+typedef __uint16_t uint16_t;
+
+typedef struct gs_battery_voltage gs_battery_voltage;
+
+typedef struct gs_battery_voltage gs_battery_voltage_t;
+
+typedef struct __gs_gui_config gs_gui_config_t;
+
+typedef struct gs_gui_event_t gs_gui_event_t;
+
+typedef struct __gs_gui gs_gui_t;
+
+typedef struct gs_ext_fc gs_ext_fc;
+
+typedef struct gs_ext_fc gs_ext_fc_t;
+
+typedef struct gs_shram gs_shram;
+
+typedef struct gs_shram gs_shram_t;
+
+typedef struct __gs_queue __gs_queue;
+
+typedef struct __gs_queue gs_queue_t;
+
+typedef struct gs_user_json_root gs_user_json_root;
+
+typedef struct gs_user_json_root gs_user_json_root_t;
+
+typedef struct duss_osal_mutex_handle_t duss_osal_mutex_handle_t;
+
+typedef struct __gs_avin_test_ctrl __gs_avin_test_ctrl;
+
+typedef struct __gs_avin_test_ctrl gs_avin_test_ctrl_t;
+
+typedef struct gs_watermarker_ctrl gs_watermarker_ctrl;
+
+typedef struct gs_watermarker_ctrl gs_watermarker_ctrl_t;
+
+typedef struct duss_mb_client duss_mb_client;
+
+typedef int32_t duss_result_t;
+
+typedef uint16_t duss_msg_attrib_t;
+
+typedef uint32_t duss_msg_id_t;
+
+typedef struct duss_mb_route_item_t duss_mb_route_item_t;
+
+typedef struct duss_mb_client *duss_mb_client_handle_t;
+
+typedef struct duss_osal_msgq_handle_t duss_osal_msgq_handle_t;
+
+typedef struct duss_osal_event_handle_t duss_osal_event_handle_t;
+
+typedef struct duss_event_ack_identify duss_event_ack_identify;
+
+typedef struct duss_event_ack_identify duss_event_ack_identify_t;
+
+typedef struct duss_event_cmd_desc duss_event_cmd_desc;
+
+typedef struct duss_event duss_event;
+
+typedef struct duss_event duss_event_t;
+
+typedef struct duss_event_cmd_desc duss_event_cmd_desc_t;
+
+typedef struct duss_hal_obj_dev_t duss_hal_obj_dev_t;
+
+typedef struct product_shm_info product_shm_info;
+
+typedef struct product_shm_info product_shm_info_t;
+
+typedef uint size_t;
+
+typedef struct modem_shmem_info_t modem_shmem_info_t;
+
+typedef struct racing_debug_info_t racing_debug_info_t;
+
+typedef struct duss_osal_task_attrib_t duss_osal_task_attrib_t;
+
+typedef long pthread_t;
+
+typedef struct duss_storage_client duss_storage_client;
+
+typedef struct duss_storage_client duss_storage_client_t;
+
+typedef enum sd_file_type
+{
+    SD_FILE_TYPE_UNKNOWN = 0,
+    SD_FILE_TYPE_FAT32 = 1,
+    SD_FILE_TYPE_EXFAT = 2,
+    SD_FILE_TYPE_MAX = 3
+} sd_file_type;
+
+typedef enum sd_file_type sd_file_type_t;
+
+typedef struct gs_storage_listener gs_storage_listener;
+
+typedef enum storage_event
+{
+    STORAGE_EVENT_NONE = 0,
+    STORAGE_EVENT_SPACE_LOW = 1
+} storage_event;
+
+typedef enum storage_event storage_event_t;
+
+typedef struct gs_storage_listener gs_storage_listener_t;
 
 typedef struct gs_sd_listener gs_sd_listener;
 
@@ -63,6 +318,241 @@ typedef enum sd_event sd_event_t;
 
 typedef struct gs_sd_listener gs_sd_listener_t;
 
+typedef struct gs_meta_listener gs_meta_listener;
+
+typedef enum meta_event
+{
+    META_EVENT_NONE = 0,
+    META_EVENT_SD_INSERT = 1,
+    META_EVENT_SD_REMOVE = 2,
+    META_EVENT_SD_FORMAT = 3
+} meta_event;
+
+typedef enum meta_event meta_event_t;
+
+typedef struct gs_meta_listener gs_meta_listener_t;
+
+typedef struct gs_playback_listener gs_playback_listener;
+
+typedef enum playback_event
+{
+    PB_EVENT_NONE = 0,
+    PB_EVENT_SD_INSERT = 1,
+    PB_EVENT_SD_REMOVE = 2,
+    PB_EVENT_SD_FORMAT = 3
+} playback_event;
+
+typedef enum playback_event playback_event_t;
+
+typedef struct gs_playback_listener gs_playback_listener_t;
+
+typedef struct sem_t sem_t;
+
+typedef struct timespec timespec;
+
+typedef struct gs_modem_link_listener gs_modem_link_listener;
+
+typedef struct gs_modem_link_listener gs_modem_link_listener_t;
+
+typedef struct glass_signal_quality_t glass_signal_quality_t;
+
+typedef struct _DUSS_MSG_RACING_CHANNEL_SCAN_REQ_t _DUSS_MSG_RACING_CHANNEL_SCAN_REQ_t;
+
+typedef struct _DUSS_MSG_RACING_CHANNEL_SCAN_REQ_t DUSS_MSG_RACING_CHANNEL_SCAN_REQ_t;
+
+typedef struct _DUSS_MSG_RACING_CHANNEL_SCAN_INFO_t _DUSS_MSG_RACING_CHANNEL_SCAN_INFO_t;
+
+typedef struct _DUSS_MSG_RACING_CHANNEL_SCAN_INFO_t DUSS_MSG_RACING_CHANNEL_SCAN_INFO_t;
+
+typedef struct _DUSS_MSG_RACING_CHANNEL_ROB_INFO_t _DUSS_MSG_RACING_CHANNEL_ROB_INFO_t;
+
+typedef struct _DUSS_MSG_RACING_CHANNEL_ROB_INFO_t DUSS_MSG_RACING_CHANNEL_ROB_INFO_t;
+
+typedef struct _DUSS_MSG_RACING_PHY_CHECK_REQ_t _DUSS_MSG_RACING_PHY_CHECK_REQ_t;
+
+typedef struct _DUSS_MSG_RACING_PHY_CHECK_REQ_t DUSS_MSG_RACING_PHY_CHECK_REQ_t;
+
+typedef struct _DUSS_MSG_RACING_PHY_CHECK_INFO_t _DUSS_MSG_RACING_PHY_CHECK_INFO_t;
+
+typedef struct _DUSS_MSG_RACING_PHY_CHECK_INFO_t DUSS_MSG_RACING_PHY_CHECK_INFO_t;
+
+typedef enum gs_modem_scan_type_t
+{
+    GS_MODEM_SCAN_ISM = 0,
+    GS_MODEM_SCAN_HAM = 1,
+    GS_MODEM_SCAN_JAPAN_HAM_5G = 2,
+    GS_MODEM_SCAN_HAM_MATCH = 3,
+    GS_MODEM_SCAN_HAM_40MHz = 4,
+    GS_MODEM_SCAN_HAM_40MHz_EXTRA = 5,
+    GS_MODEM_SCAN_UKNOWN = 6
+} gs_modem_scan_type_t;
+
+typedef union rc_set_reverse_t rc_set_reverse_t;
+
+typedef struct rc_set_all_st_t rc_set_all_st_t;
+
+typedef struct rc_set_all_ep_t rc_set_all_ep_t;
+
+typedef struct rc_set_all_st_and_rev_t rc_set_all_st_and_rev_t;
+
+typedef struct dummy_ui_ctx_t dummy_ui_ctx_t;
+
+typedef void (*duss_osal_timer_entry_t)(void *);
+
+typedef enum duss_osal_priority_t
+{
+    DUSS_OSAL_PRI_NORMAL = 0,
+    DUSS_OSAL_PRI_LOWEST = 1,
+    DUSS_OSAL_PRI_LOW1 = 3,
+    DUSS_OSAL_PRI_LOW2 = 6,
+    DUSS_OSAL_PRI_LOW3 = 9,
+    DUSS_OSAL_PRI_MID1 = 13,
+    DUSS_OSAL_PRI_MID2 = 16,
+    DUSS_OSAL_PRI_MID3 = 19,
+    DUSS_OSAL_PRI_HIGH1 = 23,
+    DUSS_OSAL_PRI_HIGH2 = 26,
+    DUSS_OSAL_PRI_HIGH3 = 29,
+    DUSS_OSAL_PRI_TIM1 = 33,
+    DUSS_OSAL_PRI_TIM2 = 36,
+    DUSS_OSAL_PRI_TIM3 = 39,
+    DUSS_OSAL_PRI_INT = 50,
+    DUSS_OSAL_PRI_HIGHEST = 99
+} duss_osal_priority_t;
+
+typedef struct factory_check factory_check;
+
+typedef struct anon_struct_conflictc3fb_for_sw anon_struct_conflictc3fb_for_sw;
+
+typedef struct anon_struct_conflictc431_for_key anon_struct_conflictc431_for_key;
+
+typedef struct duss_osal_mutex_attrib_t duss_osal_mutex_attrib_t;
+
+typedef enum gs_fan_level_t
+{
+    GS_FAN_LEVEL_0 = 0,
+    GS_FAN_LEVEL_1 = 1,
+    GS_FAN_LEVEL_2 = 2,
+    GS_FAN_LEVEL_3 = 3,
+    GS_FAN_LEVEL_4 = 4,
+    GS_FAN_LEVEL_5 = 5,
+    GS_FAN_LEVEL_MAX = 6
+} gs_fan_level_t;
+
+typedef struct _DUSS_MSG_SYSTEM_STATE_t _DUSS_MSG_SYSTEM_STATE_t;
+
+typedef struct _DUSS_MSG_SYSTEM_STATE_t DUSS_MSG_SYSTEM_STATE_t;
+
+typedef struct _DUSS_MSG_F_INDEX_MODE_t _DUSS_MSG_F_INDEX_MODE_t;
+
+typedef struct _DUSS_MSG_F_INDEX_MODE_t DUSS_MSG_F_INDEX_MODE_t;
+
+typedef struct _DUSS_MSG_QUICKVIEW_t _DUSS_MSG_QUICKVIEW_t;
+
+typedef struct _DUSS_MSG_QUICKVIEW_t DUSS_MSG_QUICKVIEW_t;
+
+typedef struct _DUSS_MSG_PHOTO_OSD_PARA_ _DUSS_MSG_PHOTO_OSD_PARA_;
+
+typedef struct _DUSS_MSG_PHOTO_OSD_PARA_ DUSS_MSG_PHOTO_OSD_PARA_t;
+
+typedef struct _DUSS_MSG_PREVIEW_OSD_PARA_t _DUSS_MSG_PREVIEW_OSD_PARA_t;
+
+typedef struct _DUSS_MSG_PREVIEW_OSD_PARA_t DUSS_MSG_PREVIEW_OSD_PARA_t;
+
+typedef struct _DUSS_MSG_HISTOGRAM_t _DUSS_MSG_HISTOGRAM_t;
+
+typedef struct _DUSS_MSG_HISTOGRAM_t DUSS_MSG_HISTOGRAM_t;
+
+typedef struct _DUSS_MSG_CAMERA_AUDIO_STATUS_t _DUSS_MSG_CAMERA_AUDIO_STATUS_t;
+
+typedef struct _DUSS_MSG_CAMERA_AUDIO_STATUS_t DUSS_MSG_CAMERA_AUDIO_STATUS_t;
+
+typedef struct _DUSS_MSG_HYPERLAPSE_LIVEVIEW_MARGIN_t _DUSS_MSG_HYPERLAPSE_LIVEVIEW_MARGIN_t;
+
+typedef struct _DUSS_MSG_HYPERLAPSE_LIVEVIEW_MARGIN_t DUSS_MSG_HYPERLAPSE_LIVEVIEW_MARGIN_t;
+
+typedef struct gs_wl_channel gs_wl_channel;
+
+typedef struct gs_wl_channel gs_wl_channel_t;
+
+typedef struct gs_local_playback_channel gs_local_playback_channel;
+
+typedef struct gs_local_playback_channel gs_local_playback_channel_t;
+
+typedef struct gs_av_in_channel gs_av_in_channel;
+
+typedef struct gs_av_in_channel gs_av_in_channel_t;
+
+typedef struct gs_rc_setting_channel gs_rc_setting_channel;
+
+typedef struct gs_rc_setting_channel gs_rc_setting_channel_t;
+
+typedef struct gs_csi_channel gs_csi_channel;
+
+typedef struct gs_csi_channel gs_csi_channel_t;
+
+typedef struct gs_non_video_channel gs_non_video_channel;
+
+typedef struct gs_non_video_channel gs_non_video_channel_t;
+
+typedef struct gs_video_channel gs_video_channel;
+
+typedef struct gs_video_channel_message gs_video_channel_message;
+
+typedef struct gs_video_channel_message gs_video_channel_message_t;
+
+typedef struct gs_video_channel gs_video_channel_t;
+
+typedef struct gs_video_channel_id gs_video_channel_id;
+
+typedef struct gs_video_channel_id gs_video_channel_id_t;
+
+typedef void (*gs_video_channel_switch_callback_t)(void *, gs_video_channel_id_t *);
+
+typedef void (*gs_video_channel_push_callback_t)(void *, gs_video_channel_id_t *);
+
+typedef struct gs_avin_us gs_avin_us;
+
+typedef struct gs_avin_us gs_avin_us_t;
+
+typedef struct AVFormatContext AVFormatContext;
+
+typedef struct audio_dec audio_dec;
+
+typedef enum decoder_event
+{
+    DEC_EVENT_INVALID = 0,
+    DEC_EVENT_A_EOS = 1,
+    DEC_EVENT_V_EOS = 2
+} decoder_event;
+
+typedef enum decoder_event dec_event_t;
+
+typedef struct audio_dec audio_dec_t;
+
+typedef struct cp_vdec cp_vdec;
+
+typedef struct cp_vdec cp_vdec_t;
+
+typedef struct vdec_video_file_info vdec_video_file_info;
+
+typedef struct vdec_video_file_info vdec_video_file_info_t;
+
+typedef longlong __int64_t;
+
+typedef __int64_t int64_t;
+
+typedef struct sqlite3 sqlite3;
+
+typedef struct gs_lv_csm gs_lv_csm;
+
+typedef struct gs_lv_pkt gs_lv_pkt;
+
+typedef struct gs_lv_pkt gs_lv_pkt_t;
+
+typedef struct gs_lv_csm gs_lv_csm_t;
+
+typedef struct duss_list_head duss_list_head;
+
 typedef struct gs_usb_listener gs_usb_listener;
 
 typedef enum usb_event
@@ -75,9 +565,22 @@ typedef enum usb_event usb_event_t;
 
 typedef struct gs_usb_listener gs_usb_listener_t;
 
-typedef struct gs_media_cmd_chnl gs_media_cmd_chnl;
+typedef struct ion_info ion_info;
 
-typedef struct gs_media_cmd_chnl gs_media_cmd_chnl_t;
+typedef struct ion_info ion_info_t;
+
+typedef enum record_state
+{
+    RECORD_STATE_IDLE = 0,
+    RECORD_STATE_RECORDING = 1,
+    RECORD_STATE_STOP_ERROR = 2,
+    RECORD_STATE_STOP_FULL = 3,
+    RECORD_STATE_STOP_WRITE_SLOW = 4,
+    RECORD_STATE_STARTING = 5,
+    RECORD_STATE_STOPPING = 6
+} record_state;
+
+typedef enum record_state record_state_t;
 
 typedef struct AVCodecContext AVCodecContext;
 
@@ -377,24 +880,6 @@ typedef struct pl_muxer_t pl_muxer_t;
 
 typedef struct pl_muxer_t *p1_muxer_handle_t;
 
-typedef enum record_mode
-{
-    RECORD_MODE_MANNUAL = 0,
-    RECORD_MODE_LOOPING = 1
-} record_mode;
-
-typedef enum record_mode record_mode_t;
-
-typedef longlong __int64_t;
-
-typedef __int64_t int64_t;
-
-typedef uint __uint32_t;
-
-typedef __uint32_t uint32_t;
-
-typedef struct duss_list_head duss_list_head;
-
 typedef struct __sFILE __sFILE;
 
 typedef long __kernel_long_t;
@@ -407,79 +892,260 @@ typedef off_t fpos_t;
 
 typedef struct __sFILE FILE;
 
-typedef struct duss_hal_obj duss_hal_obj;
+typedef struct pcm_config pcm_config;
 
-typedef struct duss_hal_obj *duss_hal_obj_handle_t;
+typedef struct pcm pcm;
 
-typedef struct duss_hal_mem_config_t duss_hal_mem_config_t;
+typedef __kernel_long_t __kernel_time_t;
 
-typedef struct duss_hal_mem_param_t duss_hal_mem_param_t;
+typedef __kernel_long_t __kernel_suseconds_t;
 
-typedef struct duss_hal_mem_buf duss_hal_mem_buf;
+typedef struct ext_fc_ops ext_fc_ops;
 
-typedef struct duss_hal_mem_buf *duss_hal_mem_handle_t;
-
-typedef struct duss_osal_mutex_attrib_t duss_osal_mutex_attrib_t;
-
-typedef struct sem_t sem_t;
-
-typedef struct duss_osal_task_attrib_t duss_osal_task_attrib_t;
-
-typedef long pthread_t;
-
-typedef struct duss_storage_client duss_storage_client;
-
-typedef struct duss_storage_client duss_storage_client_t;
-
-typedef enum sd_file_type
+typedef enum batteryState_e
 {
-    SD_FILE_TYPE_UNKNOWN = 0,
-    SD_FILE_TYPE_FAT32 = 1,
-    SD_FILE_TYPE_EXFAT = 2,
-    SD_FILE_TYPE_MAX = 3
-} sd_file_type;
+    BATTERY_OK = 0,
+    BATTERY_WARNING = 1,
+    BATTERY_CRITICAL = 2,
+    BATTERY_NOT_PRESENT = 3,
+    BATTERY_INIT = 4
+} batteryState_e;
 
-typedef enum sd_file_type sd_file_type_t;
+typedef struct DUSS_MSG_FC_RACING_DRONE_OSD_PUSH DUSS_MSG_FC_RACING_DRONE_OSD_PUSH;
 
-typedef struct gs_storage_listener gs_storage_listener;
+typedef struct DUSS_MSG_FC_RACING_DRONE_OSD_PUSH DUSS_MSG_FC_RACING_DRONE_OSD_PUSH_t;
 
-typedef enum storage_event
+typedef struct DUSS_MSG_EXT_FC_RTC DUSS_MSG_EXT_FC_RTC;
+
+typedef struct DUSS_MSG_EXT_FC_RTC DUSS_MSG_EXT_FC_RTC_t;
+
+typedef struct ext_fc_ops ext_fc_ops_t;
+
+typedef struct vr_device_ops vr_device_ops;
+
+typedef short __int16_t;
+
+typedef __int16_t int16_t;
+
+typedef struct vr_device_ops vr_device_ops_t;
+
+typedef struct local_playback_ops local_playback_ops;
+
+typedef struct local_playback_ops local_playback_ops_t;
+
+typedef struct uav_camera_ops uav_camera_ops;
+
+typedef struct __gs_camera_cmd __gs_camera_cmd;
+
+typedef struct __gs_camera_cmd gs_camera_cmd_t;
+
+typedef struct uav_camera_ops uav_camera_ops_t;
+
+typedef struct uav_gimbal_ops uav_gimbal_ops;
+
+typedef struct uav_gimbal_ops uav_gimbal_ops_t;
+
+typedef struct modem_ops modem_ops;
+
+typedef enum gs_link_stat_t
 {
-    STORAGE_EVENT_NONE = 0,
-    STORAGE_EVENT_SPACE_LOW = 1
-} storage_event;
+    GS_LINK_STAT_NORMAL = 0,
+    GS_LINK_STAT_WEAK = 1,
+    GS_LINK_STAT_LOST = 2,
+    GS_LINK_STAT_UKNOWN = 3
+} gs_link_stat_t;
 
-typedef enum storage_event storage_event_t;
+typedef struct modem_ops modem_ops_t;
 
-typedef struct gs_storage_listener gs_storage_listener_t;
+typedef struct rc_ops rc_ops;
 
-typedef struct gs_meta_listener gs_meta_listener;
+typedef struct rc_set_function_pack_t rc_set_function_pack_t;
 
-typedef enum meta_event
+typedef struct rc_set_stick_mode_pack_t rc_set_stick_mode_pack_t;
+
+typedef struct rc_set_warning_mode_pack_t rc_set_warning_mode_pack_t;
+
+typedef struct rc_monitor_pack_t rc_monitor_pack_t;
+
+typedef struct rc_ops rc_ops_t;
+
+typedef struct vcm_ops vcm_ops;
+
+typedef enum gs_main_channel_id
 {
-    META_EVENT_NONE = 0,
-    META_EVENT_SD_INSERT = 1,
-    META_EVENT_SD_REMOVE = 2,
-    META_EVENT_SD_FORMAT = 3
-} meta_event;
+    GS_FIRST_VIDEO_CHANNEL = 0,
+    GS_WL_CHANNEL = 0,
+    GS_LOCAL_PLAYBACK_CHANNEL = 1,
+    GS_AV_IN_CHANNEL = 2,
+    GS_RC_SETTING_CHANNEL = 3,
+    GS_CSI_CHANNEL = 4,
+    GS_NONE_VIDEO_CHANNEL = 5,
+    GS_VIDEO_CHANNEL_COUNT = 6,
+    GS_UNKNOWN_VIDEO_CHANNEL = 7
+} gs_main_channel_id;
 
-typedef enum meta_event meta_event_t;
+typedef enum gs_main_channel_id gs_main_channel_id_t;
 
-typedef struct gs_meta_listener gs_meta_listener_t;
+typedef struct vcm_ops vcm_ops_t;
 
-typedef struct gs_playback_listener gs_playback_listener;
+typedef struct common_cmd_ops common_cmd_ops;
 
-typedef enum playback_event
+typedef struct __gs_common_cmd __gs_common_cmd;
+
+typedef struct __gs_common_cmd gs_common_cmd_t;
+
+typedef struct common_cmd_ops common_cmd_ops_t;
+
+typedef struct debug_osd_item debug_osd_item;
+
+typedef struct debug_osd_item debug_osd_item_t;
+
+typedef uint gs_gui_event_type_t;
+
+typedef uint gs_gui_event_symbol_t;
+
+typedef struct DUSS_MSG_EXT_FC_PID DUSS_MSG_EXT_FC_PID;
+
+typedef struct DUSS_MSG_EXT_FC_PID DUSS_MSG_EXT_FC_PID_t;
+
+typedef struct DUSS_MSG_EXT_FC_AUX DUSS_MSG_EXT_FC_AUX;
+
+typedef struct DUSS_MSG_EXT_FC_AUX DUSS_MSG_EXT_FC_AUX_t;
+
+typedef struct DUSS_MSG_EXT_FC_RATE DUSS_MSG_EXT_FC_RATE;
+
+typedef struct DUSS_MSG_EXT_FC_RATE DUSS_MSG_EXT_FC_RATE_t;
+
+typedef struct DUSS_MSG_EXT_FC_SERVO DUSS_MSG_EXT_FC_SERVO;
+
+typedef struct DUSS_MSG_EXT_FC_SERVO DUSS_MSG_EXT_FC_SERVO_t;
+
+typedef struct DUSS_MSG_EXT_FC_FILTER DUSS_MSG_EXT_FC_FILTER;
+
+typedef struct DUSS_MSG_EXT_FC_FILTER DUSS_MSG_EXT_FC_FILTER_t;
+
+typedef struct DUSS_MSG_EXT_FC_ADVANCED_PID DUSS_MSG_EXT_FC_ADVANCED_PID;
+
+typedef struct DUSS_MSG_EXT_FC_ADVANCED_PID DUSS_MSG_EXT_FC_ADVANCED_PID_t;
+
+typedef struct DUSS_MSG_EXT_FC_MSP_STATUS DUSS_MSG_EXT_FC_MSP_STATUS;
+
+typedef struct DUSS_MSG_EXT_FC_MSP_STATUS DUSS_MSG_EXT_FC_MSP_STATUS_t;
+
+typedef struct DUSS_MSG_EXT_FC_RC DUSS_MSG_EXT_FC_RC;
+
+typedef struct DUSS_MSG_EXT_FC_RC DUSS_MSG_EXT_FC_RC_t;
+
+typedef struct DUSS_MSG_EXT_FC_BATTERY_STATE DUSS_MSG_EXT_FC_BATTERY_STATE;
+
+typedef struct DUSS_MSG_EXT_FC_BATTERY_STATE DUSS_MSG_EXT_FC_BATTERY_STATE_t;
+
+typedef struct DUSS_MSG_EXT_FC_OSD_CONFIG DUSS_MSG_EXT_FC_OSD_CONFIG;
+
+typedef struct DUSS_MSG_EXT_FC_OSD_CONFIG DUSS_MSG_EXT_FC_OSD_CONFIG_t;
+
+typedef struct DUSS_MSG_EXT_FC_ESC_DATA DUSS_MSG_EXT_FC_ESC_DATA;
+
+typedef struct DUSS_MSG_EXT_FC_ESC_DATA DUSS_MSG_EXT_FC_ESC_DATA_t;
+
+typedef struct DUSS_MSG_EXT_FC_VERSION DUSS_MSG_EXT_FC_VERSION;
+
+typedef struct DUSS_MSG_EXT_FC_VERSION DUSS_MSG_EXT_FC_VERSION_t;
+
+typedef enum GS_EXT_FC_OSD_STATUS
 {
-    PB_EVENT_NONE = 0,
-    PB_EVENT_SD_INSERT = 1,
-    PB_EVENT_SD_REMOVE = 2,
-    PB_EVENT_SD_FORMAT = 3
-} playback_event;
+    OSD_CONFIG_REQUEST_UPDATE = 0,
+    OSD_CONFIG_UPDATE_COMPLETE = 1
+} GS_EXT_FC_OSD_STATUS;
 
-typedef enum playback_event playback_event_t;
+typedef struct cJSON cJSON;
 
-typedef struct gs_playback_listener gs_playback_listener_t;
+typedef struct gs_watermarker_us gs_watermarker_us;
+
+typedef struct gs_watermarker_us gs_watermarker_us_t;
+
+typedef uint8_t duss_mb_channel_t;
+
+typedef uint8_t duss_mb_pack_ver_t;
+
+typedef union anon_union_conflict1232_for_channel anon_union_conflict1232_for_channel;
+
+typedef struct duss_mb_filter_t duss_mb_filter_t;
+
+typedef struct duss_mb_route_table_t duss_mb_route_table_t;
+
+typedef struct fd_set fd_set;
+
+typedef struct duss_osal_msgq_attrib_t duss_osal_msgq_attrib_t;
+
+typedef struct duss_osal_event_attrib_t duss_osal_event_attrib_t;
+
+typedef uint8_t duss_hal_state_t;
+
+typedef uint8_t duss_hal_class_t;
+
+typedef void (*duss_osal_task_entry_t)(void *);
+
+typedef struct duss_hal_storage_params duss_hal_storage_params;
+
+typedef struct duss_hal_storage_info duss_hal_storage_info;
+
+typedef struct _DUSS_MSG_RACING_CHANNEL_OCCUPIED_IPSD_t _DUSS_MSG_RACING_CHANNEL_OCCUPIED_IPSD_t;
+
+typedef struct _DUSS_MSG_RACING_CHANNEL_OCCUPIED_IPSD_t DUSS_MSG_RACING_CHANNEL_OCCUPIED_IPSD_t;
+
+typedef struct anon_struct_conflict47e0 anon_struct_conflict47e0;
+
+typedef struct rc_set_subtrim_t rc_set_subtrim_t;
+
+typedef struct rc_set_endpoint_t rc_set_endpoint_t;
+
+typedef struct rc_set_subtrim_reverse_t rc_set_subtrim_reverse_t;
+
+typedef struct _DUSS_MSG_CAM_STATE_t _DUSS_MSG_CAM_STATE_t;
+
+typedef struct _DUSS_MSG_CAM_STATE_t DUSS_MSG_CAM_STATE_t;
+
+typedef union anon_union_conflict23e3_for_u anon_union_conflict23e3_for_u;
+
+typedef union anon_union_conflict2544_for_u anon_union_conflict2544_for_u;
+
+typedef enum gs_video_channel_message_id_t
+{
+    GS_CHANNEL_MSG_HDMI_PLUG = 0,
+    GS_CHANNEL_MSG_CAMERA_WORKMODE = 1,
+    GS_CHANNEL_MSG_CAMERA_PBMODE = 2,
+    GS_CHANNEL_MSG_CAMERA_MODEL = 3,
+    GS_CHANNEL_MSG_WIRELESS_LINK_STATUS = 4,
+    GS_CHANNEL_MSG_LOCAL_PLAYBACK_ON = 5,
+    GS_CHANNEL_MSG_LOCAL_PLAYBACK_OFF = 6,
+    GS_CHANNEL_MSG_CHANNEL_ENABLE = 7,
+    GS_CHANNEL_MSG_CHANNEL_DISABLE = 8,
+    GS_CHANNEL_MSG_SUB_CHANNEL_ENABLE = 9,
+    GS_CHANNEL_MSG_SUB_CHANNEL_DISABLE = 10,
+    GS_CHANNEL_MSG_ANALOG_VIDEO_ON = 11,
+    GS_CHANNEL_MSG_ANALOG_VIDEO_OFF = 12,
+    GS_CHANNEL_MSG_RC_SETTING_ON = 13,
+    GS_CHANNEL_MSG_RC_SETTING_OFF = 14,
+    GS_CHANNEL_MSG_ID_COUNT = 15
+} gs_video_channel_message_id_t;
+
+typedef union anon_union_conflict3b31_for_field_1 anon_union_conflict3b31_for_field_1;
+
+typedef enum gs_sub_channel_id
+{
+    GS_FIRST_SUB_CHANNEL = 0,
+    GS_LIVEVIEW_SUB_CHANNEL = 0,
+    GS_PLAYBACK_SUB_CHANNEL = 1,
+    GS_RACING_SUB_CHANNEL = 2,
+    GS_HDMI_SUB_CHANNEL = 3,
+    GS_ANALOG_VIDEO_SUB_CHANNEL = 4,
+    GS_RC_SETTING_SUB_CHANNEL = 5,
+    GS_SUB_CHANNEL_COUNT = 6,
+    GS_NO_SUB_CHANNEL = 7
+} gs_sub_channel_id;
+
+typedef enum gs_sub_channel_id gs_sub_channel_id_t;
 
 typedef struct AVClass AVClass;
 
@@ -507,22 +1173,17 @@ typedef enum AVClassCategory
 
 typedef struct AVOptionRanges AVOptionRanges;
 
-typedef enum AVMediaType
-{
-    AVMEDIA_TYPE_UNKNOWN = -1,
-    AVMEDIA_TYPE_VIDEO = 0,
-    AVMEDIA_TYPE_AUDIO = 1,
-    AVMEDIA_TYPE_DATA = 2,
-    AVMEDIA_TYPE_SUBTITLE = 3,
-    AVMEDIA_TYPE_ATTACHMENT = 4,
-    AVMEDIA_TYPE_NB = 5
-} AVMediaType;
+typedef struct AVInputFormat AVInputFormat;
 
-typedef struct AVCodec AVCodec;
-
-typedef struct AVSubtitle AVSubtitle;
+typedef struct AVProbeData AVProbeData;
 
 typedef struct AVPacket AVPacket;
+
+typedef struct AVDeviceInfoList AVDeviceInfoList;
+
+typedef struct AVDeviceCapabilitiesQuery AVDeviceCapabilitiesQuery;
+
+typedef struct AVOutputFormat AVOutputFormat;
 
 typedef enum AVCodecID
 {
@@ -1279,9 +1940,123 @@ typedef enum AVCodecID
     AV_CODEC_ID_TAK = 1950507339
 } AVCodecID;
 
-typedef struct AVCodecInternal AVCodecInternal;
+typedef struct AVIOContext AVIOContext;
+
+typedef struct AVStream AVStream;
+
+typedef struct AVProgram AVProgram;
+
+typedef struct AVChapter AVChapter;
+
+typedef struct AVDictionary AVDictionary;
+
+typedef struct AVIOInterruptCB AVIOInterruptCB;
+
+typedef enum AVDurationEstimationMethod
+{
+    AVFMT_DURATION_FROM_PTS = 0,
+    AVFMT_DURATION_FROM_STREAM = 1,
+    AVFMT_DURATION_FROM_BITRATE = 2
+} AVDurationEstimationMethod;
+
+typedef struct AVPacketList AVPacketList;
 
 typedef struct AVRational AVRational;
+
+typedef struct AVFormatInternal AVFormatInternal;
+
+typedef struct AVCodec AVCodec;
+
+typedef struct AVSubtitle AVSubtitle;
+
+typedef enum AUDIO_PB_STATE
+{
+    AUDIO_PB_IDLE = 0,
+    AUDIO_PB_PREPARING = 1,
+    AUDIO_PB_PLAYING = 2,
+    AUDIO_PB_PAUSED = 3,
+    AUDIO_PB_EOF = 4,
+    AUDIO_PB_ERROR = 5,
+    AUDIO_PB_CLOSED = 6
+} AUDIO_PB_STATE;
+
+typedef enum AUDIO_PB_STATE audio_pb_state_t;
+
+typedef struct pl_decoder_t pl_decoder_t;
+
+typedef struct pl_decoder_t *pl_decoder_handle_t;
+
+typedef struct pl_decoder_itf_t pl_decoder_itf_t;
+
+typedef int (*input_data_cb)(void *, void *, int, int);
+
+typedef int (*output_data_cb)(void *, void *, int, int);
+
+typedef struct audio_resampler_t audio_resampler_t;
+
+typedef struct audio_resampler_t *audio_resampler_ptr;
+
+typedef enum VDEC_STATE
+{
+    VDEC_IDLE = 0,
+    VDEC_PREPARING = 1,
+    VDEC_PLAYING = 2,
+    VDEC_PAUSED = 3,
+    VDEC_EOF = 4,
+    VDEC_ERROR = 5,
+    VDEC_CLOSED = 6
+} VDEC_STATE;
+
+typedef enum VDEC_STATE vdec_state_t;
+
+typedef enum DUSS_FILE_FORMAT
+{
+    DUSS_FILE_FORMAT_NULL = 0,
+    DUSS_FILE_FORMAT_H264RAW = 1,
+    DUSS_FILE_FORMAT_H265RAW = 2,
+    DUSS_FILE_FORMAT_AACRAW = 3,
+    DUSS_FILE_FORMAT_AACADTSRAW = 4,
+    DUSS_FILE_FORMAT_MJPGRAW = 5,
+    DUSS_FILE_FORMAT_PRORESRAW = 6,
+    DUSS_FILE_FORMAT_PRORESRAWRAW = 7,
+    DUSS_FILE_FORMAT_USERDATARAW = 8,
+    DUSS_FILE_FORMAT_MPEG4RAW = 9,
+    DUSS_FILE_FORMAT_RAWMAX = 10,
+    DUSS_FILE_FORMAT_MP4 = 11,
+    DUSS_FILE_FORMAT_MOV = 12,
+    DUSS_FILE_FORMAT_MP2TS = 13,
+    DUSS_FILE_FORMAT_MAX = 14,
+    DUSS_FILE_FORMAT_NOT_SUPPORTED_YET = 14
+} DUSS_FILE_FORMAT;
+
+typedef int (*gs_consumer_prepare_t)(void *);
+
+typedef struct bridge_io_pkt bridge_io_pkt;
+
+typedef struct bridge_io_pkt bridge_io_pkt_t;
+
+typedef int (*gs_consumer_finish_t)(void *);
+
+typedef struct duss_hal_mem_config_t duss_hal_mem_config_t;
+
+typedef struct duss_hal_mem_param_t duss_hal_mem_param_t;
+
+typedef struct duss_hal_mem_buf duss_hal_mem_buf;
+
+typedef struct duss_hal_mem_buf *duss_hal_mem_handle_t;
+
+typedef enum AVMediaType
+{
+    AVMEDIA_TYPE_UNKNOWN = -1,
+    AVMEDIA_TYPE_VIDEO = 0,
+    AVMEDIA_TYPE_AUDIO = 1,
+    AVMEDIA_TYPE_DATA = 2,
+    AVMEDIA_TYPE_SUBTITLE = 3,
+    AVMEDIA_TYPE_ATTACHMENT = 4,
+    AVMEDIA_TYPE_NB = 5
+} AVMediaType;
+
+typedef struct AVCodecInternal AVCodecInternal;
 
 typedef enum AVPictureType
 {
@@ -1373,12 +2148,6 @@ typedef enum AVChromaLocation
     AVCHROMA_LOC_NB = 7
 } AVChromaLocation;
 
-typedef struct AVDictionary AVDictionary;
-
-typedef ushort __uint16_t;
-
-typedef __uint16_t uint16_t;
-
 typedef enum AVFieldOrder
 {
     AV_FIELD_UNKNOWN = 0,
@@ -1449,43 +2218,106 @@ typedef enum pl_muxer_config_index_t
 
 typedef struct __sbuf __sbuf;
 
-typedef struct duss_hal_obj_dev_t duss_hal_obj_dev_t;
-
-typedef int __int32_t;
-
-typedef __int32_t int32_t;
-
-typedef int32_t duss_result_t;
-
-typedef void (*duss_osal_task_entry_t)(void *);
-
-typedef enum duss_osal_priority_t
+typedef enum pcm_format
 {
-    DUSS_OSAL_PRI_NORMAL = 0,
-    DUSS_OSAL_PRI_LOWEST = 1,
-    DUSS_OSAL_PRI_LOW1 = 3,
-    DUSS_OSAL_PRI_LOW2 = 6,
-    DUSS_OSAL_PRI_LOW3 = 9,
-    DUSS_OSAL_PRI_MID1 = 13,
-    DUSS_OSAL_PRI_MID2 = 16,
-    DUSS_OSAL_PRI_MID3 = 19,
-    DUSS_OSAL_PRI_HIGH1 = 23,
-    DUSS_OSAL_PRI_HIGH2 = 26,
-    DUSS_OSAL_PRI_HIGH3 = 29,
-    DUSS_OSAL_PRI_TIM1 = 33,
-    DUSS_OSAL_PRI_TIM2 = 36,
-    DUSS_OSAL_PRI_TIM3 = 39,
-    DUSS_OSAL_PRI_INT = 50,
-    DUSS_OSAL_PRI_HIGHEST = 99
-} duss_osal_priority_t;
+    PCM_FORMAT_INVALID = -1,
+    PCM_FORMAT_S16_LE = 0,
+    PCM_FORMAT_S32_LE = 1,
+    PCM_FORMAT_S8 = 2,
+    PCM_FORMAT_S24_LE = 3,
+    PCM_FORMAT_S24_3LE = 4,
+    PCM_FORMAT_MAX = 5
+} pcm_format;
 
-typedef struct duss_hal_storage_params duss_hal_storage_params;
+typedef enum pcm_tstamp
+{
+    NONE_TSTAMP = 0,
+    ALSA_TSTAMP = 1,
+    ALSA_TSTAMP_SYNC = 2,
+    TSTAMP_TYPE_MAX = 3
+} pcm_tstamp;
 
-typedef struct duss_hal_storage_info duss_hal_storage_info;
+typedef struct snd_pcm_mmap_status snd_pcm_mmap_status;
+
+typedef struct snd_pcm_mmap_control snd_pcm_mmap_control;
+
+typedef struct snd_pcm_sync_ptr snd_pcm_sync_ptr;
+
+typedef union anon_union_conflict2c9b_for_field_3 anon_union_conflict2c9b_for_field_3;
+
+typedef struct stick_mode_self_define_t stick_mode_self_define_t;
+
+typedef struct loc_channel_addr loc_channel_addr;
+
+typedef struct ip_channel_addr ip_channel_addr;
+
+typedef struct wl_channel_addr wl_channel_addr;
+
+typedef struct uart_channel_addr uart_channel_addr;
+
+typedef struct can_channel_addr can_channel_addr;
+
+typedef struct i2c_channel_addr i2c_channel_addr;
+
+typedef struct spi_channel_addr spi_channel_addr;
+
+typedef struct hpi_channel_addr hpi_channel_addr;
+
+typedef struct usb_channel_addr usb_channel_addr;
+
+typedef struct usbacc_channel_addr usbacc_channel_addr;
+
+typedef struct icc_channel_addr icc_channel_addr;
+
+typedef struct netlink_channel_addr netlink_channel_addr;
+
+typedef struct bulk_channel_addr bulk_channel_addr;
+
+typedef enum duss_storage_client_type_t
+{
+    DUSS_STORAGE_EMMC0 = 0,
+    DUSS_STORAGE_SDCARD0 = 1,
+    DUSS_STORAGE_SDCARD1 = 2,
+    DUSS_STORAGE_UDISK = 3
+} duss_storage_client_type_t;
+
+typedef struct anon_struct_conflict2349 anon_struct_conflict2349;
+
+typedef struct anon_struct_conflict242a anon_struct_conflict242a;
+
+typedef struct gs_local_video_info gs_local_video_info;
+
+typedef struct gs_local_video_info gs_local_video_info_t;
+
+typedef struct gs_local_panorama_info gs_local_panorama_info;
+
+typedef struct gs_local_panorama_info gs_local_panorama_info_t;
 
 typedef struct AVOption AVOption;
 
 typedef struct AVOptionRange AVOptionRange;
+
+typedef struct AVCodecTag AVCodecTag;
+
+typedef struct AVPacketSideData AVPacketSideData;
+
+typedef struct AVFrac AVFrac;
+
+typedef struct anon_struct_conflict69b3c_for_info anon_struct_conflict69b3c_for_info;
+
+typedef enum AVStreamParseType
+{
+    AVSTREAM_PARSE_NONE = 0,
+    AVSTREAM_PARSE_FULL = 1,
+    AVSTREAM_PARSE_HEADERS = 2,
+    AVSTREAM_PARSE_TIMESTAMPS = 3,
+    AVSTREAM_PARSE_FULL_ONCE = 4,
+    AVSTREAM_PARSE_FULL_RAW = 1463898624
+} AVStreamParseType;
+
+typedef struct AVCodecParserContext AVCodecParserContext;
+
+typedef struct AVIndexEntry AVIndexEntry;
 
 typedef struct AVProfile AVProfile;
 
@@ -1493,7 +2325,7 @@ typedef struct AVCodecDefault AVCodecDefault;
 
 typedef struct AVSubtitleRect AVSubtitleRect;
 
-typedef struct AVPacketSideData AVPacketSideData;
+typedef struct SwrContext SwrContext;
 
 typedef struct AVBuffer AVBuffer;
 
@@ -1511,17 +2343,139 @@ typedef enum AVFrameSideDataType
     AV_FRAME_DATA_SKIP_SAMPLES = 9
 } AVFrameSideDataType;
 
-typedef uint8_t duss_hal_state_t;
+typedef struct _DUSS_MSG_APERTURE_t _DUSS_MSG_APERTURE_t;
 
-typedef uint8_t duss_hal_class_t;
+typedef struct _DUSS_MSG_APERTURE_t DUSS_MSG_APERTURE_t;
 
-typedef enum duss_storage_client_type_t
-{
-    DUSS_STORAGE_EMMC0 = 0,
-    DUSS_STORAGE_SDCARD0 = 1,
-    DUSS_STORAGE_SDCARD1 = 2,
-    DUSS_STORAGE_UDISK = 3
-} duss_storage_client_type_t;
+typedef struct _DUSS_MSG_SHUTTER_SPEED_t _DUSS_MSG_SHUTTER_SPEED_t;
+
+typedef struct _DUSS_MSG_SHUTTER_SPEED_t DUSS_MSG_SHUTTER_SPEED_t;
+
+typedef struct _DUSS_MSG_ISO_t _DUSS_MSG_ISO_t;
+
+typedef struct _DUSS_MSG_ISO_t DUSS_MSG_ISO_t;
+
+typedef struct _DUSS_MSG_EXPO_MODE_t _DUSS_MSG_EXPO_MODE_t;
+
+typedef struct _DUSS_MSG_EXPO_MODE_t DUSS_MSG_EXPO_MODE_t;
+
+typedef struct _DUSS_MSG_EV_BIAS_t _DUSS_MSG_EV_BIAS_t;
+
+typedef struct _DUSS_MSG_EV_BIAS_t DUSS_MSG_EV_BIAS_t;
+
+typedef struct _DUSS_MSG_P_STORAGE_FMT_t _DUSS_MSG_P_STORAGE_FMT_t;
+
+typedef struct _DUSS_MSG_P_STORAGE_FMT_t DUSS_MSG_P_STORAGE_FMT_t;
+
+typedef struct _DUSS_MSG_WB_t _DUSS_MSG_WB_t;
+
+typedef struct _DUSS_MSG_WB_t DUSS_MSG_WB_t;
+
+typedef struct _DUSS_MSG_SCENE_MODE_t _DUSS_MSG_SCENE_MODE_t;
+
+typedef struct _DUSS_MSG_SCENE_MODE_t DUSS_MSG_SCENE_MODE_t;
+
+typedef struct _DUSS_MSG_DIGITAL_EFFECT_t _DUSS_MSG_DIGITAL_EFFECT_t;
+
+typedef struct _DUSS_MSG_DIGITAL_EFFECT_t DUSS_MSG_DIGITAL_EFFECT_t;
+
+typedef struct _DUSS_MSG_P_SIZE_t _DUSS_MSG_P_SIZE_t;
+
+typedef struct _DUSS_MSG_P_SIZE_t DUSS_MSG_P_SIZE_t;
+
+typedef struct _DUSS_MSG_SET_FOCUS_REGION_t _DUSS_MSG_SET_FOCUS_REGION_t;
+
+typedef struct _DUSS_MSG_SET_FOCUS_REGION_t DUSS_MSG_SET_FOCUS_REGION_t;
+
+typedef struct _DUSS_MSG_CAPTURE_MODE_t _DUSS_MSG_CAPTURE_MODE_t;
+
+typedef struct _DUSS_MSG_CAPTURE_MODE_t DUSS_MSG_CAPTURE_MODE_t;
+
+typedef struct _DUSS_MSG_CONTICAP_PARAM_t _DUSS_MSG_CONTICAP_PARAM_t;
+
+typedef struct _DUSS_MSG_CONTICAP_PARAM_t DUSS_MSG_CONTICAP_PARAM_t;
+
+typedef struct _DUSS_MSG_V_STORAGE_FMT_t _DUSS_MSG_V_STORAGE_FMT_t;
+
+typedef struct _DUSS_MSG_V_STORAGE_FMT_t DUSS_MSG_V_STORAGE_FMT_t;
+
+typedef struct _DUSS_MSG_V_FORMAT_t _DUSS_MSG_V_FORMAT_t;
+
+typedef struct _DUSS_MSG_V_FORMAT_t DUSS_MSG_V_FORMAT_t;
+
+typedef struct _DUSS_MSG_VIDEO_STANDARD_t _DUSS_MSG_VIDEO_STANDARD_t;
+
+typedef struct _DUSS_MSG_VIDEO_STANDARD_t DUSS_MSG_VIDEO_STANDARD_t;
+
+typedef struct _DUSS_MSG_WORKMODE_t _DUSS_MSG_WORKMODE_t;
+
+typedef struct _DUSS_MSG_WORKMODE_t DUSS_MSG_WORKMODE_t;
+
+typedef struct _DUSS_MSG_SINGLE_PLAY_CRTL_t _DUSS_MSG_SINGLE_PLAY_CRTL_t;
+
+typedef struct _DUSS_MSG_SINGLE_PLAY_CRTL_t DUSS_MSG_SINGLE_PLAY_CRTL_t;
+
+typedef struct _DUSS_MSG_V_CRTL_t _DUSS_MSG_V_CRTL_t;
+
+typedef struct _DUSS_MSG_V_CRTL_t DUSS_MSG_V_CRTL_t;
+
+typedef struct _DUSS_MSG_SD_INFO_t _DUSS_MSG_SD_INFO_t;
+
+typedef struct _DUSS_MSG_SD_INFO_t DUSS_MSG_SD_INFO_t;
+
+typedef struct _DUSS_MSG_ZOOM_PARAM_t _DUSS_MSG_ZOOM_PARAM_t;
+
+typedef struct _DUSS_MSG_ZOOM_PARAM_t DUSS_MSG_ZOOM_PARAM_t;
+
+typedef struct _DUSS_MSG_FLIP _DUSS_MSG_FLIP;
+
+typedef struct _DUSS_MSG_FLIP DUSS_MSG_FLIP_t;
+
+typedef struct _DUSS_MSG_SHARPNESS_t _DUSS_MSG_SHARPNESS_t;
+
+typedef struct _DUSS_MSG_SHARPNESS_t DUSS_MSG_SHARPNESS_t;
+
+typedef struct _DUSS_MSG_CONTRAST_t _DUSS_MSG_CONTRAST_t;
+
+typedef struct _DUSS_MSG_CONTRAST_t DUSS_MSG_CONTRAST_t;
+
+typedef struct _DUSS_MSG_SATURATION_t _DUSS_MSG_SATURATION_t;
+
+typedef struct _DUSS_MSG_SATURATION_t DUSS_MSG_SATURATION_t;
+
+typedef struct _DUSS_MSG_CAPTURE_t _DUSS_MSG_CAPTURE_t;
+
+typedef struct _DUSS_MSG_CAPTURE_t DUSS_MSG_CAPTURE_t;
+
+typedef struct _DUSS_MSG_RECORD_t _DUSS_MSG_RECORD_t;
+
+typedef struct _DUSS_MSG_RECORD_t DUSS_MSG_RECORD_t;
+
+typedef struct _UAV_RECORD_MODE_t _UAV_RECORD_MODE_t;
+
+typedef struct _UAV_RECORD_MODE_t UAV_RECORD_MODE_t;
+
+typedef uint8_t duss_wl_prot_type_t;
+
+typedef uint8_t duss_wl_prio_t;
+
+typedef struct duss_hal_uart_config_t duss_hal_uart_config_t;
+
+typedef struct duss_hal_can_config_t duss_hal_can_config_t;
+
+typedef struct duss_hal_i2c_config_t duss_hal_i2c_config_t;
+
+typedef struct duss_hal_spi_config_t duss_hal_spi_config_t;
+
+typedef struct hpi_channel hpi_channel;
+
+typedef struct hpi_channel duss_hal_hpi_config_t;
+
+typedef struct duss_hal_usbacc_config_t duss_hal_usbacc_config_t;
+
+typedef struct duss_hal_icc_config_t duss_hal_icc_config_t;
+
+typedef struct duss_hal_bulk_config_t duss_hal_bulk_config_t;
 
 typedef enum AVOptionType
 {
@@ -1555,16 +2509,6 @@ typedef enum AVOptionType
 
 typedef union anon_union_conflictac8f4_for_default_val anon_union_conflictac8f4_for_default_val;
 
-typedef struct AVPicture AVPicture;
-
-typedef enum AVSubtitleType
-{
-    SUBTITLE_NONE = 0,
-    SUBTITLE_BITMAP = 1,
-    SUBTITLE_TEXT = 2,
-    SUBTITLE_ASS = 3
-} AVSubtitleType;
-
 typedef enum AVPacketSideDataType
 {
     AV_PKT_DATA_PALETTE = 0,
@@ -1584,38 +2528,1569 @@ typedef enum AVPacketSideDataType
     AV_PKT_DATA_METADATA_UPDATE = 77
 } AVPacketSideDataType;
 
+typedef struct AVCodecParser AVCodecParser;
+
+typedef enum AVPictureStructure
+{
+    AV_PICTURE_STRUCTURE_UNKNOWN = 0,
+    AV_PICTURE_STRUCTURE_TOP_FIELD = 1,
+    AV_PICTURE_STRUCTURE_BOTTOM_FIELD = 2,
+    AV_PICTURE_STRUCTURE_FRAME = 3
+} AVPictureStructure;
+
+typedef struct AVPicture AVPicture;
+
+typedef enum AVSubtitleType
+{
+    SUBTITLE_NONE = 0,
+    SUBTITLE_BITMAP = 1,
+    SUBTITLE_TEXT = 2,
+    SUBTITLE_ASS = 3
+} AVSubtitleType;
+
+typedef struct _DUSS_MSG_SHUTTER_A_t _DUSS_MSG_SHUTTER_A_t;
+
+typedef struct _DUSS_MSG_SHUTTER_A_t DUSS_MSG_SHUTTER_A_t;
+
+typedef struct _DUSS_MSG_V_SS_CONFIG_t _DUSS_MSG_V_SS_CONFIG_t;
+
+typedef struct _DUSS_MSG_V_SS_CONFIG_t DUSS_MSG_V_SS_CONFIG_t;
+
+typedef struct _DUSS_MSG_SD_STATUS_t _DUSS_MSG_SD_STATUS_t;
+
+typedef struct _DUSS_MSG_SD_STATUS_t DUSS_MSG_SD_STATUS_t;
+
+typedef struct _DUSS_MSG_ZOOM_CTRL_MODE_t_ _DUSS_MSG_ZOOM_CTRL_MODE_t_;
+
+typedef struct _DUSS_MSG_ZOOM_CTRL_MODE_t_ DUSS_MSG_ZOOM_CTRL_MODE_t;
+
+typedef union anon_union_conflict21a2_for_OZoomRaUnion anon_union_conflict21a2_for_OZoomRaUnion;
+
+typedef uint8_t duss_uart_parity_t;
+
+typedef uint8_t duss_uart_stopbit_t;
+
+typedef uint8_t duss_uart_wordlen_t;
+
+typedef uint8_t duss_mb_can_chip_t;
+
+typedef uint16_t duss_mb_host_id_t;
+
+typedef uint8_t duss_i2c_addr_len_t;
+
+typedef uint __u32;
+
+typedef uchar __u8;
+
+typedef ushort __u16;
+
+typedef uint16_t duss_usbacc_port_t;
+
+typedef enum duss_hal_icc_role_t
+{
+    DUSS_HAL_ICC_ROLE_SOURCE = 0,
+    DUSS_HAL_ICC_ROLE_TARGET = 1,
+    DUSS_HAL_ICC_ROLE_MAX = 2
+} duss_hal_icc_role_t;
+
+typedef enum duss_hal_icc_shm_type_t
+{
+    DUSS_HAL_ICC_SHM_SRAM = 0,
+    DUSS_HAL_ICC_SHM_DDR = 1,
+    DUSS_HAL_ICC_SHM_MAX = 2
+} duss_hal_icc_shm_type_t;
+
+typedef struct _DUSS_MSG_ZOOM_S_t _DUSS_MSG_ZOOM_S_t;
+
+typedef struct _DUSS_MSG_ZOOM_S_t DUSS_MSG_ZOOM_S_t;
+
+typedef struct _DUSS_MSG_ZOOM_P_t _DUSS_MSG_ZOOM_P_t;
+
+typedef struct _DUSS_MSG_ZOOM_P_t DUSS_MSG_ZOOM_P_t;
+
+typedef struct _DUSS_MSG_ZOOM_C_t _DUSS_MSG_ZOOM_C_t;
+
+typedef struct _DUSS_MSG_ZOOM_C_t DUSS_MSG_ZOOM_C_t;
+
+struct _DUSS_MSG_RACING_CHANNEL_OCCUPIED_IPSD_t
+{
+    uint16_t freq_idx;
+    uint8_t occupied_ind;
+    uint8_t work_ind;
+    uint32_t chn_ipsd;
+};
+
+struct __gs_avin_test_ctrl
+{
+    struct duss_osal_task_handle_t *avin_test_task;
+    _Bool avin_test_task_quit;
+    _Bool avin_test_flag;
+    _Bool init;
+    undefined field4_0x7;
+};
+
+struct gs_lv_csm
+{
+    char *name;
+    _Bool high_prior;
+    undefined field2_0x5;
+    undefined field3_0x6;
+    undefined field4_0x7;
+    void *ctx;
+    gs_consumer_prepare_t prepare;
+    int (*consume)(void *, gs_lv_pkt_t *);
+    gs_consumer_finish_t finish;
+};
+
+struct gs_usb_gadget_vt
+{
+    int fdin;
+    int fdout;
+    gs_usb_listener_t *usb_listener;
+    struct duss_osal_task_handle_t *usb_out_task;
+    _Bool usb_task_quit;
+    _Bool is_wl_chnl_orig;
+    _Bool is_wl_chnl_cur;
+    undefined field7_0x13;
+    gs_lv_src_t *lv_src;
+    gs_lv_csm_t lv_csm;
+    gs_media_cmd_chnl_t *mcc;
+    gs_modem_ctrl_t *modem_ctrl;
+    int lv_igr_cnt;
+    uint32_t listener_id;
+};
+
+struct gs_battery_voltage
+{
+    int32_t voltage;
+    float batt;
+    uint8_t series;
+    undefined field3_0x9;
+    undefined field4_0xa;
+    undefined field5_0xb;
+    enum batteryState_e state;
+};
+
+struct gs_battery_info
+{
+    uint32_t interval;
+    char *addr;
+    gs_battery_voltage_t vol;
+};
+
+struct gs_meta_listener
+{
+    void *ctx;
+    int (*event_cb)(void *, meta_event_t);
+};
+
+struct metadata_retriever
+{
+    gs_meta_listener_t meta_listener;
+    struct duss_osal_mutex_handle_t *db_mutex;
+    struct sqlite3 *p_db;
+    _Bool b_parse_pending;
+    _Bool b_running;
+    undefined field5_0x12;
+    undefined field6_0x13;
+    struct duss_osal_task_handle_t *task_retriever;
+};
+
+struct __gs_common_cmd_ctrl
+{
+    struct duss_osal_task_handle_t *cmn_cmd_task;
+    struct duss_osal_msgq_handle_t *cmn_cmd_queue;
+    _Bool cmn_cmd_task_quit;
+    undefined field3_0x9;
+    undefined field4_0xa;
+    undefined field5_0xb;
+    duss_event_client_handle_t event_client;
+    _Bool init;
+    undefined field8_0x11;
+    undefined field9_0x12;
+    undefined field10_0x13;
+    void *ctx;
+};
+
+struct gs_media_cmd_chnl
+{
+    int chnl_fd;
+    _Bool init;
+    undefined field2_0x5;
+    undefined field3_0x6;
+    undefined field4_0x7;
+};
+
+struct keys_pack_to_racing_glass_t
+{
+    uint8_t right_wheel_press : 2;
+    uint8_t right_wheel_scroll : 2;
+    uint8_t f1_press : 2;
+    uint8_t home : 2;
+    uint8_t left_wheel_scroll : 2;
+    uint8_t record_press : 2;
+    uint8_t reverved_2 : 2;
+    uint8_t reverved_3 : 2;
+};
+
+struct gs_audio_wl
+{
+    void *private_data;
+};
+
+struct anon_struct_conflictc3fb_for_sw
+{
+    uint8_t fun_key1 : 1;
+    uint8_t fun_key2 : 1;
+    uint8_t others : 6;
+};
+
+struct anon_struct_conflictc431_for_key
+{
+    uint8_t up_5d : 1;
+    uint8_t down_5d : 1;
+    uint8_t left_5d : 1;
+    uint8_t right_5d : 1;
+    uint8_t ensure_5d : 1;
+    uint8_t cancel : 1;
+    uint8_t record : 1;
+    uint8_t pair : 1;
+};
+
+struct factory_check
+{
+    uint32_t reserved : 31;
+    uint32_t result : 1;
+};
+
+struct pack_for_factory_test_t
+{
+    struct factory_check check;
+    uint16_t not_use1[6];
+    struct anon_struct_conflictc3fb_for_sw sw;
+    struct anon_struct_conflictc431_for_key key;
+    uint8_t not_use2[26];
+};
+
+struct gs_shram
+{
+    int fd;
+    uint8_t *addr;
+    int phy_size;
+    int map_offset;
+    int size;
+};
+
+struct gs_watermarker_us
+{
+    uint8_t watermarker_flag;
+    undefined field1_0x1;
+    undefined field2_0x2;
+    undefined field3_0x3;
+    int dev_mem;
+    void *uncal_nvram_va;
+    void *uncal_nvram_align_va;
+    size_t uncal_nvram_map_sz;
+};
+
+struct gs_watermarker_ctrl
+{
+    gs_media_cmd_chnl_t *mcc;
+    gs_watermarker_us_t watermarker_us;
+};
+
+struct __gs_queue
+{
+    uchar *addr;
+    uint size;
+    uint num;
+    uint writer;
+    uint reader;
+};
+
+struct __gs_gui
+{
+    _Bool gui_en;
+    undefined field1_0x1;
+    undefined field2_0x2;
+    undefined field3_0x3;
+    void *context;
+    void *dl_hdl;
+    gs_queue_t racing_drone_fc_osd_queue;
+    int (*initialize)(void **, gs_gui_config_t *);
+    void (*destroy)(void *);
+    int (*run)(void *);
+    int (*send_event)(void *, struct gs_gui_event_t *);
+};
+
+struct __gs_local_sd_info
+{
+    duss_storage_client_t *sdcard_cli;
+    _Bool sd_insert;
+    undefined field2_0x5;
+    undefined field3_0x6;
+    undefined field4_0x7;
+    sd_file_type_t sd_type;
+    uint32_t sd_total_kbytes;
+    uint32_t sd_free_kbytes;
+    uint32_t sd_minfree_kbytes;
+    uint8_t sd_status;
+    uint8_t sd_formatting;
+    _Bool sd_init;
+    undefined field12_0x1b;
+    struct duss_osal_mutex_handle_t *sd_status_mutex;
+    gs_storage_listener_t *storage_listener;
+    gs_sd_listener_t *sd_listener;
+    gs_meta_listener_t *meta_listener;
+    gs_playback_listener_t *pb_listener;
+};
+
+struct rc_set_endpoint_t
+{
+    uint8_t ep_min;
+    uint8_t ep_max;
+};
+
+struct rc_set_all_ep_t
+{
+    struct rc_set_endpoint_t a_ch;
+    struct rc_set_endpoint_t e_ch;
+    struct rc_set_endpoint_t t_ch;
+    struct rc_set_endpoint_t r_ch;
+};
+
+struct dummy_ui_ctx_t
+{
+    _Bool client;
+    undefined field1_0x1;
+    undefined field2_0x2;
+    undefined field3_0x3;
+    int sock_fd;
+    _Bool quit;
+    undefined field6_0x9;
+    undefined field7_0xa;
+    undefined field8_0xb;
+    struct duss_osal_task_handle_t *console_task;
+    struct duss_osal_timer_handle_t *console_timer;
+    struct duss_osal_event_handle_t *event;
+    struct duss_osal_task_handle_t *reader_task;
+    int (*msg_cb)(void *, void *);
+};
+
+struct rc_set_subtrim_reverse_t
+{
+    uint16_t reserved : 6;
+    uint16_t reverse : 1;
+    uint16_t subtrim : 9;
+};
+
+struct rc_set_all_st_and_rev_t
+{
+    struct rc_set_subtrim_reverse_t a_ch;
+    struct rc_set_subtrim_reverse_t e_ch;
+    struct rc_set_subtrim_reverse_t t_ch;
+    struct rc_set_subtrim_reverse_t r_ch;
+};
+
+struct rc_set_subtrim_t
+{
+    int16_t st_value;
+};
+
+struct rc_set_all_st_t
+{
+    struct rc_set_subtrim_t a_ch;
+    struct rc_set_subtrim_t e_ch;
+    struct rc_set_subtrim_t t_ch;
+    struct rc_set_subtrim_t r_ch;
+};
+
+struct anon_struct_conflict47e0
+{
+    uint8_t reserved : 4;
+    uint8_t is_reverse_r : 1;
+    uint8_t is_reverse_t : 1;
+    uint8_t is_reverse_e : 1;
+    uint8_t is_reverse_a : 1;
+};
+
+union rc_set_reverse_t
+{
+    struct anon_struct_conflict47e0 rev_bit;
+    uint8_t rev_byte;
+};
+
+struct gs_rc_ctrl
+{
+    struct duss_osal_msgq_handle_t *rc_cmd_queue;
+    struct duss_osal_task_handle_t *rc_cmd_task;
+    _Bool rc_cmd_task_quit;
+    _Bool init;
+    union rc_set_reverse_t reverse_setting;
+    int8_t reverse_valid;
+    struct rc_set_all_st_t subtrim_setting;
+    int8_t subtrim_valid;
+    struct rc_set_all_ep_t endpoint_setting;
+    int8_t endpoint_valid;
+    uint8_t stick_mode;
+    int8_t stick_valid;
+    char rc_firm_ver[128];
+    char rc_sn[20];
+    int rc_mp_state;
+    int rc_active_state;
+    int8_t version_valid;
+    struct rc_set_all_st_and_rev_t subtrim_endpiont_setting;
+    uint8_t rc_lock_stat;
+    _Bool rc_monitor_quit;
+    undefined field20_0xc7;
+    struct duss_osal_task_handle_t *rc_monitor;
+    duss_event_client_handle_t event_client;
+    struct dummy_ui_ctx_t dummy_ui_ctx;
+    void *ctx;
+};
+
+struct gs_wl_ctrl
+{
+    gs_media_cmd_chnl_t *mcc;
+    _Bool wl_start;
+    undefined field2_0x5;
+    undefined field3_0x6;
+    undefined field4_0x7;
+};
+
+struct racing_debug_info_t
+{
+    uint8_t sdr_log_dump;
+    uint8_t vstream_dump;
+    uint8_t record;
+    uint32_t enc_sto_frm_drop_cnt;
+    uint32_t enc_lv_frm_drop_cnt;
+    uint32_t csi_frm_drop_cnt;
+    uint16_t channel_status;
+    uint16_t cam_frame_interval;
+    uint16_t outlier_frame_interval;
+    uint16_t outlier_frame_interval_cnt;
+    uint16_t cam_error;
+    uint16_t cam_ae_bv;
+    uint16_t cam_ae_dv;
+    uint32_t cam_ae_exp_time;
+    uint16_t cam_ae_iso;
+    uint16_t cam_awb_temp;
+    uint16_t cam_atm_value;
+    uint16_t cam_scene_mode;
+    uint16_t cam_snr;
+    uint16_t cam_ae_speed;
+    uint16_t cam_ltm_str;
+    uint16_t cam_saturation;
+    uint16_t cam_saturation_bias;
+    uint16_t cam_gamma;
+    uint16_t cam_snr_temp;
+    uint8_t cam_resolution;
+    uint8_t cam_angle;
+    uint8_t cam_mode;
+    uint8_t cam_ev;
+    uint8_t cam_satur;
+    uint8_t cam_white_balance;
+    int32_t shtl_ddr_temp;
+    int32_t shtl_acpu_temp;
+    int32_t shtl_modem_temp;
+    int32_t shtl_media_temp;
+    int32_t shtl_omc_temp;
+    uint8_t shtl_cp_report;
+    uint8_t shtl_cp_seq;
+    char shtl_ap_ver[128];
+    char shtl_board_sn[16];
+    uint8_t uav_rec_mode;
+    uint8_t uav_low_power_mode;
+    uint8_t uav_power_policy;
+    uint8_t HDVT_pref;
+    uint8_t enc_roi;
+    uint8_t sbus_mode;
+    char shtl_hardware_version[16];
+    uint8_t camera_type;
+};
+
+struct gs_debug_ctrl
+{
+    struct __gs_info *gs_info;
+    product_shm_info_t *pdt_shm_va;
+    void *pdt_shm_align_va;
+    size_t pdt_shm_map_sz;
+    struct modem_shmem_info_t *plf_shm_va;
+    void *plf_shm_align_va;
+    size_t plf_shm_map_sz;
+    struct racing_debug_info_t rac_dbg_info;
+    undefined field8_0x116;
+    undefined field9_0x117;
+};
+
+struct timeval
+{
+    __kernel_time_t tv_sec;
+    __kernel_suseconds_t tv_usec;
+};
+
+struct pcm_config
+{
+    uint channels;
+    uint rate;
+    uint period_size;
+    uint period_count;
+    enum pcm_format format;
+    enum pcm_tstamp tstamp_type;
+    uint start_threshold;
+    uint stop_threshold;
+    uint silence_threshold;
+    uint silence_size;
+    int avail_min;
+};
+
+struct gs_aout
+{
+    struct pcm_config config;
+    struct pcm *pcm_device;
+    uint32_t buffer_size;
+};
+
+struct gs_lv_src
+{
+    int lv_dmi_fd;
+    _Bool force_stop;
+    undefined field2_0x5;
+    undefined field3_0x6;
+    undefined field4_0x7;
+    gs_media_cmd_chnl_t *mcc;
+    struct duss_osal_task_handle_t *lpc_ctrl_task;
+    _Bool lpc_ctrl_task_quit;
+    undefined field8_0x11;
+    undefined field9_0x12;
+    undefined field10_0x13;
+    struct duss_osal_msgq_handle_t *lpc_ctrl_queue;
+    struct duss_osal_task_handle_t *lpc_data_task;
+    _Bool lpc_data_task_quit;
+    _Bool lpc_data_eos;
+    undefined field15_0x1e;
+    undefined field16_0x1f;
+    gs_lv_csm_t *csm;
+};
+
+struct gs_user_json_root
+{
+    struct cJSON *user_file_json_root;
+    struct cJSON *device_sn_json_root;
+};
+
+struct gs_video_channel
+{
+    int (*start)(struct gs_video_channel *);
+    int (*stop)(struct gs_video_channel *);
+    _Bool (*handle_message)(struct gs_video_channel *, gs_video_channel_message_t *);
+    _Bool (*update_channel)(struct gs_video_channel *);
+    struct gs_video_channel_manager *chnl_mgr;
+    _Bool ready;
+    _Bool enable;
+    _Bool lazy_stop;
+    _Bool force_switch;
+    gs_main_channel_id_t id;
+    gs_sub_channel_id_t sub_id;
+    char *name;
+    _Bool sub_chnl_enable[6];
+    undefined field13_0x2a;
+    undefined field14_0x2b;
+};
+
+struct gs_wl_channel
+{
+    gs_video_channel_t base;
+    _Bool wl_link;
+    uint8_t cam_workmode;
+    uint8_t cam_pbmode;
+    uint8_t cam_model;
+};
+
+struct gs_local_playback_channel
+{
+    gs_video_channel_t base;
+    char video_path[256];
+    char audio_path[256];
+};
+
+struct gs_csi_channel
+{
+    gs_video_channel_t base;
+    _Bool hdmi_plugin;
+    undefined field2_0x2d;
+    undefined field3_0x2e;
+    undefined field4_0x2f;
+};
+
+struct gs_rc_setting_channel
+{
+    gs_video_channel_t base;
+};
+
+struct gs_non_video_channel
+{
+    gs_video_channel_t base;
+};
+
+struct gs_video_channel_id
+{
+    gs_main_channel_id_t main_chnl_id;
+    gs_sub_channel_id_t sub_chnl_id;
+};
+
+struct gs_av_in_channel
+{
+    gs_video_channel_t base;
+    _Bool av_plugin;
+    undefined field2_0x2d;
+    undefined field3_0x2e;
+    undefined field4_0x2f;
+};
+
+struct gs_video_channel_manager
+{
+    gs_wl_channel_t wl_chnl;
+    gs_local_playback_channel_t local_pb_chnl;
+    gs_av_in_channel_t av_in_chnl;
+    gs_rc_setting_channel_t rc_setting_chnl;
+    gs_csi_channel_t csi_chnl;
+    gs_non_video_channel_t non_video_chnl;
+    gs_video_channel_t *cur_chnl;
+    gs_video_channel_t *indexed_chnls[6];
+    gs_video_channel_t *prior_ordered_chnls[6];
+    gs_video_channel_t *pend_release_chnl;
+    gs_video_channel_id_t last_chnl_id;
+    struct __gs_info *gs_info;
+    gs_video_channel_switch_callback_t chnl_switch_cb;
+    void *chnl_switch_data;
+    gs_video_channel_push_callback_t chnl_push_cb;
+    void *chnl_push_data;
+    int8_t ignore_cam_push_cnt;
+    uint8_t cam_model;
+    uint8_t cam_workmode;
+    uint8_t cam_pbmode;
+    uint8_t racing_mode;
+    undefined field21_0x36d;
+    undefined field22_0x36e;
+    undefined field23_0x36f;
+    uint32_t listener_id;
+    struct duss_osal_task_handle_t *chnl_ctrl_task;
+    _Bool chnl_ctrl_task_quit;
+    undefined field27_0x379;
+    undefined field28_0x37a;
+    undefined field29_0x37b;
+    struct duss_osal_msgq_handle_t *chnl_ctrl_queue;
+    struct duss_osal_mutex_handle_t *chnl_ctrl_lock;
+};
+
+struct duss_osal_mutex_attrib_t
+{
+    char *name;
+};
+
+struct gs_buzzer_info
+{
+    struct duss_osal_mutex_handle_t *buzzer_mutex;
+    struct duss_osal_mutex_attrib_t buzzer_mutex_attr;
+    struct duss_osal_task_handle_t *buzzer_play_sound;
+    _Bool buzzer_play_sound_quit;
+    undefined field4_0xd;
+    undefined field5_0xe;
+    undefined field6_0xf;
+    int buzzer_enable_fd;
+    int buzzer_period_fd;
+    int buzzer_duty_fd;
+    _Bool buzzer_bat_enable;
+    undefined field11_0x1d;
+    undefined field12_0x1e;
+    undefined field13_0x1f;
+};
+
+struct _DUSS_MSG_RC_BAT_INFO_t
+{
+    uint32_t bat_remain_value;
+    uint8_t bat_remain_ratio;
+    uint8_t bat_is_charging;
+};
+
+struct glass_signal_quality_t
+{
+    uint8_t direction;
+    uint8_t signal_percent;
+    uint8_t energy1_uav_or_gnd;
+    uint8_t energy2_uav_or_gnd;
+};
+
+struct _DUSS_MSG_RACING_PHY_CHECK_REQ_t
+{
+    uint8_t ant_check;
+    uint8_t reserved[2];
+};
+
+struct _DUSS_MSG_RACING_PHY_CHECK_INFO_t
+{
+    uint8_t tx_ant_status;
+    uint8_t rx_ant_status;
+    uint8_t tx_ant_numbers;
+    uint8_t rx_ant_numbers;
+    uint8_t reserved;
+};
+
+struct _DUSS_MSG_RACING_CHANNEL_SCAN_INFO_t
+{
+    uint8_t chnl_num;
+    uint8_t bw;
+    DUSS_MSG_RACING_CHANNEL_OCCUPIED_IPSD_t chn_info[16];
+    uint8_t flag;
+};
+
+struct _DUSS_MSG_RACING_CHANNEL_SCAN_REQ_t
+{
+    uint8_t chnl_num;
+    uint8_t bw;
+    uint16_t freq_idx[16];
+};
+
+struct gs_modem_link_listener
+{
+    void (*link_chg_cb)(void *, _Bool);
+    void *cb_ctx;
+};
+
+struct _DUSS_MSG_RACING_CHANNEL_ROB_INFO_t
+{
+    uint8_t left_time;
+    uint8_t robber_name[7];
+};
+
+struct gs_modem_ctrl
+{
+    int8_t gls_role;
+    uint8_t gls_count;
+    uint16_t conf_items[17];
+    struct duss_osal_mutex_handle_t *status_mutex_handle;
+    _Bool modem_monitor_quit;
+    undefined field5_0x29;
+    undefined field6_0x2a;
+    undefined field7_0x2b;
+    struct duss_osal_task_handle_t *modem_monitor;
+    uint8_t modem_state;
+    uint8_t sdr_role;
+    _Bool in_factory_mode;
+    _Bool in_aging_test;
+    _Bool flag_pairing_finished;
+    uint8_t last_modem_state;
+    uint8_t rob_flag;
+    undefined field16_0x37;
+    duss_event_client_handle_t event_client;
+    uint32_t seq_id;
+    gs_modem_link_listener_t listeners[8];
+    struct glass_signal_quality_t signal_quality;
+    DUSS_MSG_RACING_CHANNEL_SCAN_REQ_t scan_req;
+    DUSS_MSG_RACING_CHANNEL_SCAN_INFO_t scan_info;
+    DUSS_MSG_RACING_CHANNEL_ROB_INFO_t rob_info;
+    DUSS_MSG_RACING_PHY_CHECK_REQ_t check_req;
+    DUSS_MSG_RACING_PHY_CHECK_INFO_t check_info;
+    undefined field26_0x139;
+    undefined field27_0x13a;
+    undefined field28_0x13b;
+    enum gs_modem_scan_type_t modem_scan_type;
+    uint8_t area_id;
+    uint8_t nation_code[2];
+    uint8_t area_active_flag;
+    int dev_mem;
+    void *uncal_nvram_va;
+    void *uncal_nvram_align_va;
+    size_t uncal_nvram_map_sz;
+    struct glass_signal_quality_t rc_signal_quality;
+    uint16_t update_bandwidth;
+    _Bool power_level_expanded;
+    _Bool bw_pending;
+};
+
+struct DUSS_MSG_EXT_FC_RTC
+{
+    uint16_t year;
+    uint8_t month;
+    uint8_t day;
+    uint8_t hours;
+    uint8_t minutes;
+    uint8_t seconds;
+    uint16_t millis;
+};
+
+struct DUSS_MSG_EXT_FC_RATE
+{
+    uint8_t roll_rates;
+    uint8_t roll_expos;
+    uint8_t roll_s_rates;
+    uint8_t pitch_s_rates;
+    uint8_t yaw_s_rates;
+    uint8_t dyn_thr;
+    uint8_t thr_mid;
+    uint8_t thr_expos;
+    uint16_t tpa_bp;
+    uint8_t yaw_expos;
+    uint8_t yaw_rates;
+    uint8_t pitch_rates;
+    uint8_t pitch_expos;
+    uint8_t throttle_limit_type;
+    uint8_t throttle_limit_percent;
+    uint16_t rate_limit_roll;
+    uint16_t rate_limit_pitch;
+    uint16_t rate_limit_yaw;
+};
+
+struct DUSS_MSG_EXT_FC_FILTER
+{
+    uint8_t gyro_lpf1;
+    uint16_t dterm_lpf1;
+    uint16_t yaw_lpf;
+    uint16_t gyro_no1;
+    uint16_t gyro_no1_cut;
+    uint16_t dterm_no1;
+    uint16_t dterm_no1_cut;
+    uint16_t gyro_no2;
+    uint16_t gyro_no2_cut;
+    uint8_t dterm_lpf1_type;
+    uint8_t gyro_hw_cut;
+    uint8_t gyro_hw32_cut;
+    uint16_t gyro_lpf1_alt;
+    uint16_t gyro_lpf2;
+    uint8_t gyro_lpf1_type;
+    uint8_t gyro_lpf2_type;
+    uint16_t dterm_lpf2;
+    uint8_t dterm_ft2_type;
+    uint16_t dyn_lpf_gyro_min_hz;
+    uint16_t dyn_lpf_gyro_max_hz;
+    uint16_t dyn_lpf_dterm_min_hz;
+    uint16_t dyn_lpf_dterm_max_hz;
+    uint8_t dyn_notch_range;
+    uint8_t dyn_notch_width_percent;
+    uint16_t dyn_notch_q;
+    uint16_t dyn_notch_min_hz;
+    uint8_t gyro_rpm_notch_harmonics;
+    uint8_t gyro_rpm_notch_min;
+};
+
+struct DUSS_MSG_EXT_FC_AUX
+{
+    uint8_t aux_id;
+    uint8_t aux_index;
+    uint8_t start_step;
+    uint8_t end_step;
+};
+
+struct DUSS_MSG_EXT_FC_BATTERY_STATE
+{
+    uint8_t cell;
+    uint16_t capacity;
+    uint8_t voltage;
+    uint16_t MAhDrawn;
+    uint16_t amperage;
+    uint8_t state;
+    uint16_t battVoltage;
+};
+
+struct DUSS_MSG_EXT_FC_RC
+{
+    uint16_t chnl_1_v;
+    uint16_t chnl_2_v;
+    uint16_t chnl_3_v;
+    uint16_t chnl_4_v;
+    uint16_t chnl_5_v;
+    uint16_t chnl_6_v;
+    uint16_t chnl_7_v;
+    uint16_t chnl_8_v;
+    uint16_t chnl_9_v;
+    uint16_t chnl_10_v;
+    uint16_t chnl_11_v;
+    uint16_t chnl_12_v;
+    uint16_t chnl_13_v;
+    uint16_t chnl_14_v;
+    uint16_t chnl_15_v;
+    uint16_t chnl_16_v;
+    uint16_t chnl_17_v;
+    uint16_t chnl_18_v;
+};
+
+struct DUSS_MSG_EXT_FC_MSP_STATUS
+{
+    uint16_t task_delta_time;
+    uint16_t i2c_error_counter;
+    uint16_t sensor_status;
+    uint32_t flight_flags_lsb;
+    uint8_t pid_index;
+    uint16_t sysAvgLoad;
+    uint8_t pid_count;
+    uint8_t rate_index;
+    uint8_t flight_count;
+    uint8_t arming_count;
+    uint32_t arming_flags;
+    uint8_t flight_flags_msb;
+};
+
+struct DUSS_MSG_EXT_FC_ESC_DATA
+{
+    uint8_t temperature;
+    uint16_t rpm;
+};
+
+struct DUSS_MSG_EXT_FC_OSD_CONFIG
+{
+    uint8_t osdFlags;
+    uint8_t videoSystems;
+    uint8_t units;
+    uint8_t rssi_alarm;
+    uint16_t cap_alarm;
+    uint8_t reserved;
+    uint8_t item_count;
+    uint16_t alt_alarm;
+    uint16_t item_position[100];
+    uint8_t stat_count;
+    uint8_t stat_state[100];
+    uint8_t timer_count;
+    uint16_t timer[10];
+    uint16_t enablewarnings;
+    uint8_t warning_count;
+    uint32_t warnings;
+    uint8_t profile_count;
+    uint8_t profile_index;
+    uint8_t stick_overlay;
+};
+
+struct DUSS_MSG_EXT_FC_SERVO
+{
+    uint16_t min;
+    uint16_t max;
+    uint16_t middle;
+    uint8_t rate;
+    uint8_t ffchnl;
+    uint32_t reverse;
+};
+
+struct DUSS_MSG_EXT_FC_VERSION
+{
+    uint8_t major;
+    uint8_t minor;
+    uint8_t patch_level;
+};
+
+struct DUSS_MSG_EXT_FC_ADVANCED_PID
+{
+    uint16_t reserved1;
+    uint16_t reserved2;
+    uint16_t reserved3;
+    uint8_t reserved4;
+    uint8_t vbat_comp;
+    uint8_t feedForwardTrans;
+    uint8_t reserved5;
+    uint8_t reserved6;
+    uint8_t reserved7;
+    uint8_t reserved8;
+    uint16_t rateAcelLimit;
+    uint16_t yawrateAcelLimit;
+    uint8_t levelAngleLimit;
+    uint8_t reserved9;
+    uint16_t ThrottleThreshold;
+    uint16_t AcceleratorGain;
+    uint16_t reserved10;
+    uint8_t rotation;
+    uint8_t smartFF;
+    uint8_t relax;
+    uint8_t relax_type;
+    uint8_t abs_control_gain;
+    uint8_t throttle_boost;
+    uint8_t acro_trainer_angle_limit;
+    uint16_t RollFF;
+    uint16_t PitchFF;
+    uint16_t YawFF;
+    uint8_t ag_mode;
+    uint8_t d_min_roll;
+    uint8_t d_min_pitch;
+    uint8_t d_min_yaw;
+    uint8_t d_min_gain;
+    uint8_t d_min_advance;
+    uint8_t use_integrated_yaw;
+    uint8_t integrated_yaw_relax;
+    uint8_t iterm_relax_cutoff;
+};
+
+struct DUSS_MSG_FC_RACING_DRONE_OSD_PUSH
+{
+    uint8_t GPS_3D_fix;
+    uint8_t GPS_numSat;
+    int32_t Lattitude;
+    int32_t Longtitude;
+    uint16_t GPS_altitude;
+    uint16_t GPS_speed;
+    uint16_t GPS_distance_home;
+    int16_t GPS_direction_home;
+    int16_t angx;
+    int16_t angy;
+    int16_t heading;
+    int32_t estAlt;
+    int16_t vario;
+    uint8_t vbat;
+    uint16_t intPowerMeterSum;
+    uint16_t rssi;
+    uint16_t amperage;
+};
+
+struct DUSS_MSG_EXT_FC_PID
+{
+    uint8_t roll_p;
+    uint8_t roll_i;
+    uint8_t roll_d;
+    uint8_t pitch_p;
+    uint8_t pitch_i;
+    uint8_t pitch_d;
+    uint8_t yaw_p;
+    uint8_t yaw_i;
+    uint8_t yaw_d;
+    uint8_t angle_str;
+    uint8_t horizon_str;
+    uint8_t horizon_trans;
+    uint8_t mag_p;
+    uint8_t mag_i;
+    uint8_t mag_d;
+};
+
+struct gs_ext_fc
+{
+    uint8_t requestType;
+    DUSS_MSG_EXT_FC_PID_t pid;
+    DUSS_MSG_EXT_FC_AUX_t aux[20];
+    DUSS_MSG_EXT_FC_RATE_t rate;
+    DUSS_MSG_EXT_FC_SERVO_t servo[8];
+    DUSS_MSG_EXT_FC_FILTER_t filter;
+    DUSS_MSG_EXT_FC_ADVANCED_PID_t pid_adv;
+    DUSS_MSG_EXT_FC_MSP_STATUS_t msp_status;
+    DUSS_MSG_EXT_FC_RC_t rc;
+    DUSS_MSG_EXT_FC_BATTERY_STATE_t batt;
+    DUSS_MSG_EXT_FC_OSD_CONFIG_t osd_config;
+    DUSS_MSG_EXT_FC_ESC_DATA_t esc_data[4];
+    DUSS_MSG_EXT_FC_RTC_t fc_rtc;
+    char name[17];
+    DUSS_MSG_EXT_FC_VERSION_t fc_version;
+    DUSS_MSG_FC_RACING_DRONE_OSD_PUSH_t osd_info;
+    undefined field16_0x31b;
+    enum GS_EXT_FC_OSD_STATUS osd_status;
+    struct duss_osal_task_handle_t *get_osd_config;
+    _Bool get_osd_quit;
+    undefined field20_0x325;
+    undefined field21_0x326;
+    undefined field22_0x327;
+};
+
+struct _DUSS_MSG_HISTOGRAM_t
+{
+    uint8_t Op : 1;
+    uint8_t Reserved : 7;
+};
+
+struct anon_struct_conflict2349
+{
+    uint16_t DataDisp : 1;
+    uint16_t PertureDisp : 1;
+    uint16_t ShutterSpeedDisp : 1;
+    uint16_t ISODisp : 1;
+    uint16_t EvBiasDisp : 1;
+    uint16_t SharpnessDisp : 1;
+    uint16_t ContrastDisp : 1;
+    uint16_t SaturationDisp : 1;
+    uint16_t Res : 8;
+};
+
+union anon_union_conflict23e3_for_u
+{
+    struct anon_struct_conflict2349 bits;
+    uint16_t Value;
+};
+
+struct _DUSS_MSG_PHOTO_OSD_PARA_
+{
+    union anon_union_conflict23e3_for_u u;
+};
+
+struct anon_struct_conflict242a
+{
+    uint32_t DataDisp : 1;
+    uint32_t PertureDisp : 1;
+    uint32_t ShutterSpeedDisp : 1;
+    uint32_t ISODisp : 1;
+    uint32_t AeModeDisp : 1;
+    uint32_t FlashLightDisp : 1;
+    uint32_t WbDisp : 1;
+    uint32_t EvBiasDisp : 1;
+    uint32_t SharpnessDisp : 1;
+    uint32_t ContrastDisp : 1;
+    uint32_t SaturationDisp : 1;
+    uint32_t CapModeDisp : 1;
+    uint32_t PhoSizeDisp : 1;
+    uint32_t PhoVideoQualityDisp : 1;
+    uint32_t HistogramsDisp : 1;
+    uint32_t BatteryPowerDisp : 1;
+    uint32_t Res : 16;
+};
+
+union anon_union_conflict2544_for_u
+{
+    struct anon_struct_conflict242a bits;
+    uint16_t Value;
+};
+
+struct _DUSS_MSG_PREVIEW_OSD_PARA_t
+{
+    union anon_union_conflict2544_for_u u;
+};
+
+struct _DUSS_MSG_QUICKVIEW_t
+{
+    uint8_t Time : 7;
+    uint8_t Op : 1;
+};
+
+struct _DUSS_MSG_CAMERA_AUDIO_STATUS_t
+{
+    uint8_t reversed : 6;
+    uint8_t mic_opened : 1;
+    uint8_t speaker_opened : 1;
+    uint8_t speaker_audio_volumn;
+};
+
+struct _DUSS_MSG_F_INDEX_MODE_t
+{
+    uint8_t Mode;
+};
+
+struct _DUSS_MSG_CAM_STATE_t
+{
+    uint32_t WifiCon : 1;
+    uint32_t UsbCon : 1;
+    uint32_t TimeSync : 1;
+    uint32_t Capture : 3;
+    uint32_t Record : 2;
+    uint32_t SensorErr : 1;
+    uint32_t SdInserted : 1;
+    uint32_t SdStatus : 4;
+    uint32_t FwUpgrading : 1;
+    uint32_t FwUpgradErr : 2;
+    uint32_t OverHeat : 1;
+    uint32_t CapForbit : 1;
+    uint32_t Storage : 1;
+    uint32_t ContiCap : 1;
+    uint32_t Hdmi : 1;
+    uint32_t Encrypt : 2;
+    uint32_t FileSync : 1;
+    uint32_t RCBtmForbid : 1;
+    uint32_t InFocus : 1;
+    uint32_t gimbal_state : 1;
+    uint32_t is_tracking : 1;
+    uint32_t is_hyperlapse : 1;
+    uint32_t Reserved : 2;
+};
+
+struct _DUSS_MSG_SYSTEM_STATE_t
+{
+    DUSS_MSG_CAM_STATE_t CamState;
+    uint8_t WorkMode;
+};
+
+struct _DUSS_MSG_HYPERLAPSE_LIVEVIEW_MARGIN_t
+{
+    float x;
+    float y;
+};
+
+struct _DUSS_MSG_CAMERA_STATUS_PUSH_t
+{
+    DUSS_MSG_SYSTEM_STATE_t CameraStatus;
+    uint32_t Capacity;
+    uint32_t SpareCap;
+    uint32_t RemainShots;
+    uint32_t RemainTime;
+    DUSS_MSG_F_INDEX_MODE_t FileIndexMode;
+    DUSS_MSG_QUICKVIEW_t PhotoQuickViewPara;
+    DUSS_MSG_PHOTO_OSD_PARA_t PhotoOSDPara;
+    DUSS_MSG_PREVIEW_OSD_PARA_t PreviewOSDPara;
+    uint16_t RecordTime;
+    uint8_t CapCapacityNum;
+    DUSS_MSG_HISTOGRAM_t Histogram;
+    uint8_t CameraModel;
+    uint16_t CurrentRecordingTime;
+    uint8_t ProtocolType;
+    uint8_t RawSupport;
+    uint8_t LcdFormat;
+    uint8_t Reserved;
+    uint8_t CropMode;
+    uint8_t NdFilter;
+    uint32_t ErrCode;
+    uint8_t mic_audio_volumn;
+    uint8_t camera_advance_mode;
+    uint8_t StreamQuality;
+    DUSS_MSG_CAMERA_AUDIO_STATUS_t audio_status;
+    DUSS_MSG_HYPERLAPSE_LIVEVIEW_MARGIN_t HyperlapseMargin;
+};
+
 struct duss_list_head
 {
     struct duss_list_head *next;
     struct duss_list_head *prev;
 };
 
-struct duss_hal_obj_dev_t
+struct gs_storage_listener
+{
+    void *ctx;
+    int (*event_cb)(void *, storage_event_t);
+};
+
+struct gs_lv_rec_ctrl
+{
+    uint8_t *lv_rec_state;
+    gs_lv_src_t *lv_src;
+    gs_lv_csm_t lv_csm;
+    gs_storage_listener_t storage_listener;
+    struct duss_osal_mutex_handle_t *list_mutex;
+    struct duss_list_head frame_list;
+    int num_in_list;
+    int frames_received;
+    _Bool b_wrf_running;
+    undefined field9_0x3d;
+    undefined field10_0x3e;
+    undefined field11_0x3f;
+    int frames_write;
+    struct duss_osal_task_handle_t *task_wrf;
+};
+
+struct gs_avin_us
+{
+    uint8_t brightness;
+    uint8_t saturation;
+    undefined field2_0x2;
+    undefined field3_0x3;
+    int dev_mem;
+    void *uncal_nvram_va;
+    void *uncal_nvram_align_va;
+    size_t uncal_nvram_map_sz;
+};
+
+struct gs_av_in_ctrl
+{
+    gs_media_cmd_chnl_t *mcc;
+    _Bool avin_start;
+    undefined field2_0x5;
+    undefined field3_0x6;
+    undefined field4_0x7;
+    gs_avin_us_t avin_us;
+};
+
+struct gs_camera_cmd_ctrl_t
+{
+    struct duss_osal_task_handle_t *cam_cmd_task;
+    struct duss_osal_msgq_handle_t *cam_cmd_queue;
+    _Bool cam_cmd_task_quit;
+    undefined field3_0x9;
+    undefined field4_0xa;
+    undefined field5_0xb;
+    duss_event_client_handle_t event_client;
+    _Bool init;
+    _Bool set_best_liveview;
+    uint8_t lv_format;
+    undefined field10_0x13;
+    struct duss_osal_task_handle_t *cam_monitor_task;
+    _Bool cam_monitor_task_quit;
+    undefined field13_0x19;
+    undefined field14_0x1a;
+    undefined field15_0x1b;
+    void *ctx;
+};
+
+struct gs_bl
+{
+    duss_hal_obj_handle_t i2c_obj[2];
+    uint8_t brightness_value;
+    undefined field2_0x9;
+    undefined field3_0xa;
+    undefined field4_0xb;
+    float lr_ratio;
+    uint8_t mode;
+    _Bool b_quit_monitor;
+    undefined field8_0x12;
+    undefined field9_0x13;
+    struct duss_osal_task_handle_t *lcd_monitor_task;
+};
+
+struct _DUSS_MSG_RC_MS_LINK_STATUS
+{
+    uint8_t pair_role;
+    uint8_t master_link_stat : 4;
+    uint8_t master_device_type : 4;
+    uint8_t slave_link_stat : 4;
+    uint8_t slave_device_type : 4;
+    uint8_t coach_role;
+    uint8_t double_rc_stat;
+};
+
+struct duss_osal_timer_attrib_t
 {
     char *name;
-    duss_hal_state_t obj_state;
-    duss_hal_class_t obj_class;
-    uint16_t obj_index;
-    int32_t obj_refcnt;
-    struct duss_osal_mutex_handle_t *obj_lock;
-    struct duss_osal_mutex_handle_t *app_lock;
-    duss_result_t (*open)(duss_hal_obj_handle_t, void *);
-    duss_result_t (*close)(duss_hal_obj_handle_t);
-    duss_result_t (*set_cfg)(duss_hal_obj_handle_t, void *);
-    duss_result_t (*get_cfg)(duss_hal_obj_handle_t, void *);
-    duss_result_t (*start)(duss_hal_obj_handle_t, void *);
-    duss_result_t (*stop)(duss_hal_obj_handle_t, void *);
+    duss_osal_timer_entry_t entry;
+    void *param;
+    uint32_t timeout_us;
+    int32_t repeat_times;
+    enum duss_osal_priority_t priority;
 };
 
-struct duss_hal_mem_config_t
+struct gs_fan_info
 {
-    uint32_t reserved;
+    struct duss_osal_task_handle_t *fan_adjust_task;
+    _Bool fan_adjust_task_quit;
+    undefined field2_0x5;
+    undefined field3_0x6;
+    undefined field4_0x7;
+    int fan_pwm_period;
+    int fan_pwm_duty;
+    enum gs_fan_level_t fan_pwm_level;
+    _Bool fan_enable;
+    undefined field9_0x15;
+    undefined field10_0x16;
+    undefined field11_0x17;
 };
 
-struct __sbuf
+struct __gs_use_times_info
 {
-    uchar *_base;
-    int _size;
+    uint8_t magic[2];
+    _Bool flag;
+    uint32_t times;
+};
+
+struct gs_usb_listener
+{
+    void *ctx;
+    int (*event_cb)(void *, usb_event_t);
+};
+
+struct gs_sd_listener
+{
+    void *ctx;
+    int (*event_cb)(void *, sd_event_t);
+};
+
+struct gs_lv_transcode
+{
+    ion_info_t *ion_info;
+    struct duss_osal_mutex_handle_t *rec_mutex;
+    record_state_t cur_state;
+    record_state_t tgt_state;
+    _Bool b_rec_running;
+    undefined field5_0x11;
+    undefined field6_0x12;
+    undefined field7_0x13;
+    struct duss_osal_task_handle_t *rec_thread;
+    uint8_t *lv_rec_state;
+    gs_local_sd_info_t *sd_info;
+    gs_sd_listener_t sd_listener;
+    gs_usb_listener_t usb_listener;
+    gs_media_cmd_chnl_t *mcc;
+    int dmi_data_fd;
+    int file_idx;
+    char file_name[128];
+    struct AVCodecContext *avcodec_ctx;
+    p1_muxer_handle_t muxer;
+    record_mode_t rec_mode;
+    int video_stream_index;
+    undefined field21_0xcc;
+    undefined field22_0xcd;
+    undefined field23_0xce;
+    undefined field24_0xcf;
+    int64_t cur_rec_time;
+    char *sps_buf;
+    uint32_t sps_len;
+    struct duss_osal_mutex_handle_t *video_list_mutex;
+    struct duss_list_head video_list;
+    int num_frames;
+    _Bool b_running;
+    _Bool b_eos;
+    undefined field33_0xf2;
+    undefined field34_0xf3;
+    struct duss_osal_task_handle_t *task_rx;
+    uint32_t frames_received;
+    uint32_t frames_write;
+    uint32_t last_key_frm_idx;
+    uint32_t last_frame_idx;
+    _Bool b_wrf_running;
+    undefined field41_0x109;
+    undefined field42_0x10a;
+    undefined field43_0x10b;
+    FILE *p_file;
+    struct duss_osal_task_handle_t *task_wrf;
+    int first_idx_in_file;
+    _Bool b_pending_new_file;
+    _Bool b_avin_recording;
+    undefined field49_0x11a;
+    undefined field50_0x11b;
+    undefined field51_0x11c;
+    undefined field52_0x11d;
+    undefined field53_0x11e;
+    undefined field54_0x11f;
+    int64_t cur_rec_time_ms;
+    char srt_file_name[128];
+    _Bool b_srt_record_running;
+    _Bool b_srt_switch_new_file;
+    undefined field59_0x1aa;
+    undefined field60_0x1ab;
+    FILE *p_srt_file;
+    struct duss_osal_task_handle_t *task_srt_record;
+    undefined field63_0x1b4;
+    undefined field64_0x1b5;
+    undefined field65_0x1b6;
+    undefined field66_0x1b7;
+};
+
+struct __gs_info
+{
+    duss_event_client_handle_t event_client;
+    duss_hal_obj_handle_t vmem_obj;
+    duss_hal_obj_handle_t gpio_obj;
+    int32_t dev_mem;
+    gs_debug_ctrl_t dbg_ctrl;
+    struct duss_osal_task_handle_t *sdr_status_listen_task;
+    _Bool b_sdr_status_quit;
+    undefined field7_0x12d;
+    undefined field8_0x12e;
+    undefined field9_0x12f;
+    gs_local_sd_info_t sd_info;
+    struct duss_osal_timer_handle_t *sd_monitor_timer;
+    DUSS_MSG_RC_BAT_INFO_t bat_info;
+    undefined field13_0x16a;
+    undefined field14_0x16b;
+    gs_battery_info_t batt_info;
+    uint8_t current_uav_rc_sdr_mode;
+    undefined field17_0x185;
+    undefined field18_0x186;
+    undefined field19_0x187;
+    gs_modem_ctrl_t modem_ctrl;
+    DUSS_MSG_RC_MS_LINK_STATUS_t ms_link_stat;
+    _Bool b_active_quit;
+    _Bool b_rc_mp_state_got;
+    _Bool b_rc_active_get_pending;
+    _Bool b_uav_mp_state_got;
+    _Bool b_uav_active_get_pending;
+    uint8_t uav_mp_state;
+    uint8_t uav_active_state;
+    uint8_t gls_active_state;
+    undefined field30_0x2f1;
+    undefined field31_0x2f2;
+    undefined field32_0x2f3;
+    struct duss_osal_task_handle_t *get_activate_task;
+    gs_use_times_info_t use_times_before_active;
+    undefined field35_0x2ff;
+    gs_rc_ctrl_t rc_ctrl;
+    struct keys_pack_to_racing_glass_t key_state;
+    _Bool key_flag;
+    undefined field39_0x3f7;
+    struct duss_osal_timer_handle_t *keyscan_task_handle;
+    struct duss_osal_timer_attrib_t keyscan_task_attrib;
+    struct duss_osal_timer_handle_t *detect_taking_off_task_handle;
+    struct duss_osal_timer_attrib_t detect_taking_off_task_attrib;
+    struct pack_for_factory_test_t factory_test_key_info;
+    gs_buzzer_info_t buzzer_info;
+    gs_fan_info_t fan_info;
+    uint8_t cam_model;
+    uint8_t cam_work_mode;
+    _Bool check_cam_work_mode;
+    _Bool cam_is_pb;
+    gs_common_cmd_ctrl_t cmn_cmd_ctrl;
+    struct gs_camera_cmd_ctrl_t cam_cmd_ctrl;
+    DUSS_MSG_CAMERA_STATUS_PUSH_t uav_cam_stat;
+    undefined field54_0x50b;
+    gs_video_channel_manager_t chnl_mgr;
+    gs_wl_ctrl_t wl_ctrl;
+    gs_av_in_ctrl_t avin_ctrl;
+    vdec_local_player_t *player;
+    metadata_retriever_t metad_rt;
+    uint8_t lv_rec_state;
+    undefined field61_0x8d1;
+    undefined field62_0x8d2;
+    undefined field63_0x8d3;
+    gs_lv_src_t lv_src;
+    gs_lv_rec_ctrl_t lv_rec_ctrl;
+    gs_usb_gadget_vt_t usb_vt;
+    gs_lv_transcode_t lv_transcode;
+    gs_aout_t gs_aout;
+    gs_audio_wl_t audio_wl;
+    gs_media_cmd_chnl_t media_cmd_chnl;
+    gs_bl_t gs_bl;
+    struct timeval disarm_start;
+    uint8_t disarm_flag;
+    uint8_t low_power_mode;
+    undefined field75_0xb9a;
+    undefined field76_0xb9b;
+    uint32_t rtc_listener_id;
+    struct duss_osal_timer_handle_t *rtc_brdcst_timer;
+    struct duss_osal_timer_handle_t *lcdc_blending_check_timer;
+    gs_gui_t gui;
+    gs_ext_fc_t ext_fc;
+    gs_shram_t pdt_shram;
+    gs_shram_t plf_shram;
+    char user_data_file_name[64];
+    gs_queue_t user_data_queue;
+    struct duss_osal_timer_handle_t *user_data_update_timer;
+    struct duss_osal_task_handle_t *user_data_sender_task;
+    struct duss_osal_task_handle_t *device_sn_check_task;
+    _Bool is_pc_connect;
+    uint8_t user_privacy_setting;
+    uint16_t user_vt_sn_id;
+    uint16_t user_rc_sn_id;
+    uint8_t user_country_code[2];
+    _Bool b_sender_task_quit;
+    _Bool b_sn_check_task_quit;
+    gs_user_json_root_t json_root_info;
+    undefined field97_0xf9a;
+    undefined field98_0xf9b;
+    struct duss_osal_mutex_handle_t *user_queue_mutex;
+    gs_avin_test_ctrl_t avin_test_ctrl;
+    _Bool is_speaker_test_start;
+    undefined field102_0xfa9;
+    undefined field103_0xfaa;
+    undefined field104_0xfab;
+    struct duss_osal_mutex_handle_t *test_status_mutex;
+    uint8_t uav_power_status;
+    uint8_t arm_flag_from_uav;
+    uint8_t exit_flag;
+    undefined field109_0xfb3;
+    gs_watermarker_ctrl_t watermarker_ctrl;
+    undefined field111_0xfcc;
+    undefined field112_0xfcd;
+    undefined field113_0xfce;
+    undefined field114_0xfcf;
+};
+
+struct ip_channel_addr
+{
+    char *ifx;
+    uint16_t loc_port;
+    undefined field2_0x6;
+    undefined field3_0x7;
+    char *address;
+    uint16_t rmt_port;
+    undefined field6_0xe;
+    undefined field7_0xf;
+};
+
+struct pthread_cond_t
+{
+    int32_t __private[1];
+};
+
+struct AVFrac
+{
+    int64_t val;
+    int64_t num;
+    int64_t den;
 };
 
 struct duss_hal_storage_info
@@ -1634,64 +4109,16 @@ struct duss_hal_storage_info
     int block_size;
 };
 
-struct AVPacket
+struct AVIndexEntry
 {
-    struct AVBufferRef *buf;
-    undefined field1_0x4;
-    undefined field2_0x5;
-    undefined field3_0x6;
-    undefined field4_0x7;
-    int64_t pts;
-    int64_t dts;
-    uint8_t *data;
-    int size;
-    int stream_index;
-    int flags;
-    struct AVPacketSideData *side_data;
-    int side_data_elems;
-    int duration;
-    void (*destruct)(struct AVPacket *);
-    void *priv;
-    undefined field16_0x3c;
-    undefined field17_0x3d;
-    undefined field18_0x3e;
-    undefined field19_0x3f;
     int64_t pos;
-    int64_t convergence_duration;
-    _Bool is_last_section;
-    undefined field23_0x51;
-    undefined field24_0x52;
-    undefined field25_0x53;
-    int32_t nal_total_size;
+    int64_t timestamp;
+    int flags : 2;
+    int size : 30;
+    int min_distance;
 };
 
 struct AVBuffer
-{
-};
-
-struct sem_t
-{
-    uint count;
-};
-
-struct AVOptionRanges
-{
-    struct AVOptionRange **range;
-    int nb_ranges;
-    int nb_components;
-};
-
-struct AVCodecDescriptor
-{
-    enum AVCodecID id;
-    enum AVMediaType type;
-    char *name;
-    char *long_name;
-    int props;
-    char **mime_types;
-};
-
-struct AVCodecInternal
 {
 };
 
@@ -1701,67 +4128,112 @@ struct AVRational
     int den;
 };
 
-union anon_union_conflictac8f4_for_default_val
+struct AVChapter
 {
-    int64_t i64;
-    double dbl;
-    char *str;
-    struct AVRational q;
+    int id;
+    struct AVRational time_base;
+    undefined field2_0xc;
+    undefined field3_0xd;
+    undefined field4_0xe;
+    undefined field5_0xf;
+    int64_t start;
+    int64_t end;
+    struct AVDictionary *metadata;
+    undefined field9_0x24;
+    undefined field10_0x25;
+    undefined field11_0x26;
+    undefined field12_0x27;
 };
 
-struct gs_playback_listener
+struct gs_gui_event_t
 {
-    void *ctx;
-    int (*event_cb)(void *, playback_event_t);
+    gs_gui_event_type_t type;
+    gs_gui_event_symbol_t symbol;
+    float posx;
+    float posy;
+    float dx;
+    float dy;
+    float yaw;
+    float pitch;
+    float roll;
 };
 
-struct gs_sd_listener
+struct _DUSS_MSG_V_CRTL_t
 {
-    void *ctx;
-    int (*event_cb)(void *, sd_event_t);
+    uint8_t Op;
+    uint32_t time_offset;
 };
 
-struct gs_meta_listener
+struct pthread_mutex_t
 {
-    void *ctx;
-    int (*event_cb)(void *, meta_event_t);
+    int32_t __private[1];
 };
 
-struct duss_hal_storage_params
-{
-    enum duss_storage_client_type_t client_id;
-    void *user_data;
-    void (*callback)(struct duss_hal_storage_info *, void *);
-};
-
-struct MpegEncContext
-{
-};
-
-struct AVBufferRef
-{
-    struct AVBuffer *buffer;
-    uint8_t *data;
-    int size;
-};
-
-struct duss_osal_mutex_attrib_t
+struct duss_osal_event_attrib_t
 {
     char *name;
 };
 
-struct duss_osal_mutex_handle_t
+struct duss_osal_event_handle_t
 {
-    struct duss_osal_mutex_attrib_t attrib;
-    struct sem_t sema;
+    struct duss_osal_event_attrib_t attrib;
+    struct pthread_mutex_t mutex;
+    struct pthread_cond_t cond;
+    uint32_t data;
+    int32_t flag;
 };
 
-struct duss_hal_mem_buf
+struct modem_ops
 {
+    int (*pairing_control)(void *, uint32_t);
+    int (*set_pairing_role)(void *, uint32_t);
+    int (*get_link_stat)(void *, enum gs_link_stat_t *);
+    int (*get_bandwidth)(void *, uint16_t *);
+    int (*set_bandwidth)(void *, uint16_t);
+    int (*get_chnl)(void *, uint16_t *);
+    int (*set_chnl)(void *, uint16_t);
+    int (*rob_chnl)(void *, uint16_t);
+    int (*rob_chnl_cancel)(void *);
+    int (*get_rob_left_time)(void *, uint8_t *);
+    int (*get_rob_flag)(void *, uint8_t *);
+    int (*clear_rob_flag)(void *);
+    int (*set_public_chnl)(void *);
+    int (*is_drone_broadcast)(void *, uint16_t *);
+    int (*enable_drone_broadcast)(void *, uint16_t);
+    int (*listen_broadcast)(void *, uint16_t);
+    int (*is_silent)(void *, uint16_t *);
+    int (*set_chnl_scan_info)(void *, uint8_t, uint8_t);
+    int (*scan_chnl_x)(void *, uint8_t, uint8_t);
+    int (*check_ant_status)(void *);
+    int (*if_new_chnl_scan_info)(void *, uint8_t *);
+    int (*if_new_phy_check_info)(void *, uint8_t *);
+    int (*if_update_bandwidth_pending)(void *, uint8_t *);
+    int (*clear_scan_flag)(void *);
+    int (*clear_check_flag)(void *);
+    int (*get_chnl_scan_info)(void *, uint8_t, uint8_t *, uint8_t *, uint32_t *);
+    int (*get_ant_status)(void *, uint8_t *, uint8_t *);
+    int (*get_dbg_mcs)(void *, uint16_t *);
+    int (*set_dbg_mcs)(void *, uint16_t);
+    int (*get_dbg_harq)(void *, uint16_t *);
+    int (*set_dbg_harq)(void *, uint16_t);
+    int (*get_dbg_codec_rate)(void *, uint16_t *);
+    int (*set_dbg_codec_rate)(void *, uint16_t);
+    int (*get_signal_quality)(void *, struct glass_signal_quality_t *);
+    int (*get_rc_signal_quality)(void *, struct glass_signal_quality_t *);
+    int (*set_bandwidth_mode)(void *, uint16_t);
+    int (*change_silent_mode)(void *, uint8_t);
+    int (*get_chnl_cnt)(void *, uint16_t *);
+    int (*get_freq_by_index)(void *, uint16_t *, uint16_t);
+    int (*get_scan_type)(void *, uint8_t *);
+    int (*get_wl_area_id)(void *, uint8_t *);
+    int (*get_pairing_finish_flag)(void *, uint8_t *);
+    int (*check_conf_items)(void *);
 };
 
-struct AVCodecDefault
+struct _UAV_RECORD_MODE_t
 {
+    uint8_t type;
+    uint8_t value;
 };
 
 struct AVFrameSideData
@@ -1772,82 +4244,126 @@ struct AVFrameSideData
     struct AVDictionary *metadata;
 };
 
-struct duss_hal_mem_param_t
+struct _DUSS_MSG_APERTURE_t
 {
-    uint32_t reserved;
+    uint16_t Value;
 };
 
-struct duss_osal_task_attrib_t
+struct _DUSS_MSG_VIDEO_STANDARD_t
 {
-    char *name;
-    duss_osal_task_entry_t entry;
-    void *param;
-    enum duss_osal_priority_t priority;
-    uint32_t stack_size;
-    uint32_t time_slice;
-    _Bool detached;
-    undefined field7_0x19;
-    undefined field8_0x1a;
-    undefined field9_0x1b;
-    uint32_t affinity_mask;
+    uint8_t Value;
 };
 
-struct AVPicture
+struct AVCodecParser
 {
-    uint8_t *data[8];
-    int linesize[8];
-};
-
-struct AVSubtitleRect
-{
-    int x;
-    int y;
-    int w;
-    int h;
-    int nb_colors;
-    struct AVPicture pict;
-    enum AVSubtitleType type;
-    char *text;
-    char *ass;
-    int flags;
-};
-
-struct gs_usb_listener
-{
-    void *ctx;
-    int (*event_cb)(void *, usb_event_t);
-};
-
-struct AVOption
-{
-    char *name;
-    char *help;
-    int offset;
-    enum AVOptionType type;
-    union anon_union_conflictac8f4_for_default_val default_val;
-    double min;
-    double max;
-    int flags;
-    char *unit;
-};
-
-struct AVHWAccel
-{
-    char *name;
-    enum AVMediaType type;
-    enum AVCodecID id;
-    enum AVPixelFormat pix_fmt;
-    int capabilities;
-    struct AVHWAccel *next;
-    int (*alloc_frame)(struct AVCodecContext *, struct AVFrame *);
-    int (*start_frame)(struct AVCodecContext *, uint8_t *, uint32_t);
-    int (*decode_slice)(struct AVCodecContext *, uint8_t *, uint32_t);
-    int (*end_frame)(struct AVCodecContext *);
-    int frame_priv_data_size;
-    void (*decode_mb)(struct MpegEncContext *);
-    int (*init)(struct AVCodecContext *);
-    int (*uninit)(struct AVCodecContext *);
+    int codec_ids[5];
     int priv_data_size;
+    int (*parser_init)(struct AVCodecParserContext *);
+    int (*parser_parse)(struct AVCodecParserContext *, struct AVCodecContext *, uint8_t **, int *, uint8_t *, int);
+    void (*parser_close)(struct AVCodecParserContext *);
+    int (*split)(struct AVCodecContext *, uint8_t *, int);
+    struct AVCodecParser *next;
+};
+
+struct hpi_channel
+{
+    __u32 priority;
+    __u8 major_id : 4;
+    __u8 minor_id : 4;
+    undefined field3_0x5;
+    __u16 order;
+};
+
+struct hpi_channel_addr
+{
+    char *obj_name;
+    duss_hal_hpi_config_t cfg;
+};
+
+struct _DUSS_MSG_WORKMODE_t
+{
+    uint8_t WorkMode;
+};
+
+struct timespec
+{
+    __kernel_time_t tv_sec;
+    long tv_nsec;
+};
+
+struct ext_fc_ops
+{
+    int (*get_craft_name)(void *, char *);
+    int (*get_pid_profile_index)(void *, uint8_t *);
+    int (*get_rate_profile_index)(void *, uint8_t *);
+    int (*get_osd_profile_index)(void *, uint8_t *);
+    int (*select_file)(void *, uint8_t, uint8_t);
+    int (*copy_file)(void *, uint8_t, uint8_t, uint8_t);
+    int (*write_eeprom)(void *);
+    int (*get_rc_channel)(void *, uint8_t, uint16_t *);
+    int (*get_aux_id)(void *, uint8_t *, uint8_t, uint8_t *, uint8_t *);
+    int (*get_aux_mode)(void *, uint8_t, uint8_t *, uint8_t *, uint8_t *);
+    int (*set_aux_mode)(void *, uint8_t, uint8_t, uint8_t, uint8_t);
+    int (*set_request_type)(void *, uint8_t);
+    int (*get_request_type)(void *, uint8_t *);
+    int (*get_ag_gain)(void *, uint16_t *);
+    int (*set_ag_gain)(void *, uint16_t);
+    int (*get_ag_thr)(void *, uint16_t *);
+    int (*set_ag_thr)(void *, uint16_t);
+    int (*get_thr_boost)(void *, uint8_t *);
+    int (*set_thr_boost)(void *, uint8_t);
+    int (*get_ff_trans)(void *, uint8_t *);
+    int (*set_ff_trans)(void *, uint8_t);
+    int (*get_filter)(void *, uint8_t, uint16_t *);
+    int (*set_filter)(void *, uint8_t, uint16_t);
+    int (*get_rate)(void *, uint8_t, uint8_t *);
+    int (*set_rate)(void *, uint8_t, uint8_t);
+    int (*get_super_rate)(void *, uint8_t, uint8_t *);
+    int (*set_super_rate)(void *, uint8_t, uint8_t);
+    int (*get_expo)(void *, uint8_t, uint8_t *);
+    int (*set_expo)(void *, uint8_t, uint8_t);
+    int (*get_dyn_thr)(void *, uint8_t *);
+    int (*set_dyn_thr)(void *, uint8_t);
+    int (*get_thr_mid)(void *, uint8_t *);
+    int (*set_thr_mid)(void *, uint8_t);
+    int (*get_thr_expo)(void *, uint8_t *);
+    int (*set_thr_expo)(void *, uint8_t);
+    int (*get_tpa)(void *, uint16_t *);
+    int (*set_tpa)(void *, uint16_t);
+    int (*get_pid)(void *, uint8_t, uint8_t *);
+    int (*set_pid)(void *, uint8_t, uint8_t);
+    int (*get_pid_f)(void *, uint8_t, uint16_t *);
+    int (*set_pid_f)(void *, uint8_t, uint16_t);
+    int (*get_battery_state)(void *, enum batteryState_e *);
+    int (*get_battery_voltage)(void *, uint16_t *);
+    int (*get_battery_avg_voltage)(void *, uint16_t *);
+    int (*get_battery_amperage)(void *, uint16_t *);
+    int (*get_battery_mah)(void *, uint16_t *);
+    int (*get_battery_usage)(void *, uint16_t *);
+    int (*get_battery_power)(void *, uint16_t *);
+    int (*set_arming_disabled)(void *, uint8_t);
+    int (*get_arming_disabled)(void *, uint32_t *);
+    int (*get_fc_version)(void *, uint8_t *, uint8_t *, uint8_t *);
+    int (*set_sbus_mode)(void *, uint8_t);
+    int (*get_racing_osd_info)(void *, DUSS_MSG_FC_RACING_DRONE_OSD_PUSH_t *);
+    int (*get_osd_position)(void *, int, _Bool *, int *, int *);
+    int (*get_units)(void *, uint8_t *);
+    int (*get_fly_mode)(void *, uint16_t *);
+    int (*get_rtc_date)(void *, DUSS_MSG_EXT_FC_RTC_t *);
+    int (*get_esc_temperature)(void *, uint8_t *);
+};
+
+struct duss_hal_usbacc_config_t
+{
+    duss_usbacc_port_t port;
+};
+
+struct usbacc_channel_addr
+{
+    char *obj_name;
+    struct duss_hal_usbacc_config_t cfg;
+    undefined field2_0x6;
+    undefined field3_0x7;
 };
 
 struct AVCodecContext
@@ -2085,40 +4601,291 @@ struct AVCodecContext
     undefined field230_0x3df;
 };
 
-struct AVSubtitle
+struct _DUSS_MSG_SATURATION_t
 {
-    uint16_t format;
-    undefined field1_0x2;
-    undefined field2_0x3;
-    uint32_t start_display_time;
-    uint32_t end_display_time;
-    uint num_rects;
-    struct AVSubtitleRect **rects;
-    undefined field7_0x14;
-    undefined field8_0x15;
-    undefined field9_0x16;
-    undefined field10_0x17;
-    int64_t pts;
+    int8_t Value;
 };
 
-struct duss_osal_task_handle_t
+struct _DUSS_MSG_ZOOM_P_t
 {
-    struct duss_osal_task_attrib_t attrib;
-    pthread_t thread;
+    uint16_t Ratio;
 };
 
-struct duss_storage_client
+struct _DUSS_MSG_ZOOM_S_t
 {
-    _Bool start_flag;
-    undefined field1_0x1;
-    undefined field2_0x2;
-    undefined field3_0x3;
-    struct duss_hal_storage_params param;
-    struct duss_hal_storage_info info;
+    uint16_t Step : 8;
+    uint16_t Direction : 1;
+    uint16_t Reserved : 7;
 };
 
-struct AVDictionary
+struct _DUSS_MSG_ZOOM_C_t
 {
+    uint16_t Speed : 8;
+    uint16_t Direction : 1;
+    uint16_t Reserved : 7;
+};
+
+union anon_union_conflict21a2_for_OZoomRaUnion
+{
+    DUSS_MSG_ZOOM_S_t ZoomS;
+    DUSS_MSG_ZOOM_P_t ZoomP;
+    DUSS_MSG_ZOOM_C_t ZoomC;
+};
+
+struct _DUSS_MSG_ZOOM_CTRL_MODE_t_
+{
+    uint8_t DZoomMode : 2;
+    uint8_t Reserved1 : 1;
+    uint8_t DZoomCtrl : 1;
+    uint8_t OZoomMode : 2;
+    uint8_t Reserved2 : 1;
+    uint8_t OZoomCtrl : 1;
+};
+
+struct _DUSS_MSG_ZOOM_PARAM_t
+{
+    DUSS_MSG_ZOOM_CTRL_MODE_t Mode;
+    union anon_union_conflict21a2_for_OZoomRaUnion OZoomRaUnion;
+    union anon_union_conflict21a2_for_OZoomRaUnion DZoomRaUnion;
+};
+
+struct _DUSS_MSG_CAPTURE_MODE_t
+{
+    uint8_t Op;
+    uint8_t Mcap_Cnt;
+    uint8_t Ccap_Type;
+    uint8_t Ccap_Cnt;
+    uint16_t Ccap_Interval;
+};
+
+struct _DUSS_MSG_ISO_t
+{
+    uint8_t Value;
+};
+
+struct _DUSS_MSG_SD_STATUS_t
+{
+    uint8_t Inserted : 1;
+    uint8_t Status : 4;
+    uint8_t Reserved : 3;
+};
+
+struct _DUSS_MSG_SD_INFO_t
+{
+    DUSS_MSG_SD_STATUS_t SdStatus;
+    uint32_t Capacity;
+    uint32_t SpareCap;
+    uint32_t RemainShots;
+    uint32_t RemainTime;
+};
+
+struct _DUSS_MSG_EXPO_MODE_t
+{
+    uint8_t Mode;
+    uint8_t ScnMode;
+};
+
+struct _DUSS_MSG_FLIP
+{
+    uint8_t type;
+    uint8_t angle;
+};
+
+struct _DUSS_MSG_SHARPNESS_t
+{
+    int8_t Value;
+};
+
+struct _DUSS_MSG_CONTICAP_PARAM_t
+{
+    uint8_t Type;
+    uint8_t Cnt;
+    uint16_t Interval;
+};
+
+struct _DUSS_MSG_P_STORAGE_FMT_t
+{
+    uint8_t Fmt;
+};
+
+struct _DUSS_MSG_RECORD_t
+{
+    uint8_t Op : 2;
+    uint8_t type : 4;
+    uint8_t Reserved : 2;
+};
+
+struct _DUSS_MSG_WB_t
+{
+    uint8_t Mode;
+    uint8_t WbCt;
+};
+
+struct _DUSS_MSG_CONTRAST_t
+{
+    int8_t Value;
+};
+
+struct _DUSS_MSG_SHUTTER_A_t
+{
+    uint16_t Value : 15;
+    uint16_t Flag : 1;
+    uint8_t Decimal;
+};
+
+struct _DUSS_MSG_SHUTTER_SPEED_t
+{
+    uint8_t Mode;
+    DUSS_MSG_SHUTTER_A_t ShutterA;
+};
+
+struct _DUSS_MSG_DIGITAL_EFFECT_t
+{
+    uint8_t Effect;
+};
+
+struct _DUSS_MSG_EV_BIAS_t
+{
+    uint8_t Bias;
+};
+
+struct _DUSS_MSG_V_STORAGE_FMT_t
+{
+    uint8_t Fmt;
+};
+
+struct _DUSS_MSG_SINGLE_PLAY_CRTL_t
+{
+    uint32_t FileIndex;
+};
+
+struct _DUSS_MSG_SCENE_MODE_t
+{
+    uint8_t Mode;
+};
+
+struct _DUSS_MSG_SET_FOCUS_REGION_t
+{
+    float x;
+    float y;
+};
+
+struct _DUSS_MSG_V_SS_CONFIG_t
+{
+    uint8_t Op : 1;
+    uint8_t Reserved : 7;
+};
+
+struct _DUSS_MSG_V_FORMAT_t
+{
+    uint8_t FSResolution;
+    uint8_t FrameRate;
+    uint8_t Fov;
+    DUSS_MSG_V_SS_CONFIG_t SSConfig;
+    uint8_t SSResolution;
+};
+
+struct _DUSS_MSG_P_SIZE_t
+{
+    uint8_t Size;
+    uint8_t AspectRatio;
+};
+
+struct _DUSS_MSG_CAPTURE_t
+{
+    uint8_t Op;
+};
+
+union anon_union_conflict2c9b_for_field_3
+{
+    DUSS_MSG_APERTURE_t aperture;
+    DUSS_MSG_SHUTTER_SPEED_t shut_spd;
+    DUSS_MSG_ISO_t iso;
+    DUSS_MSG_EXPO_MODE_t expo_mode;
+    DUSS_MSG_EV_BIAS_t ev_bias;
+    DUSS_MSG_P_STORAGE_FMT_t p_storage;
+    DUSS_MSG_WB_t wb;
+    DUSS_MSG_SCENE_MODE_t scene_mode;
+    DUSS_MSG_DIGITAL_EFFECT_t digit_effect;
+    DUSS_MSG_P_SIZE_t p_size;
+    DUSS_MSG_SET_FOCUS_REGION_t focus;
+    DUSS_MSG_CAPTURE_MODE_t cap_mode;
+    DUSS_MSG_CONTICAP_PARAM_t conticap;
+    DUSS_MSG_V_STORAGE_FMT_t v_storage;
+    DUSS_MSG_V_FORMAT_t v_fmt;
+    DUSS_MSG_VIDEO_STANDARD_t v_std;
+    DUSS_MSG_WORKMODE_t work_mode;
+    DUSS_MSG_SINGLE_PLAY_CRTL_t play_ctrl_data;
+    DUSS_MSG_V_CRTL_t video_ctrl_data;
+    DUSS_MSG_SD_INFO_t sd_info;
+    DUSS_MSG_ZOOM_PARAM_t zoom_param;
+    DUSS_MSG_FLIP_t flip_mode;
+    DUSS_MSG_SHARPNESS_t sharpness;
+    DUSS_MSG_CONTRAST_t contrast;
+    DUSS_MSG_SATURATION_t saturation;
+    uint8_t lv_format;
+    DUSS_MSG_CAPTURE_t cap_photo;
+    DUSS_MSG_RECORD_t cap_video;
+    UAV_RECORD_MODE_t rec_mode;
+    uint8_t uav_low_power_mode;
+    uint8_t uav_power_policy;
+    uint8_t HDVT_pref;
+    uint8_t enc_roi;
+    uint8_t white_balance;
+};
+
+struct __gs_camera_cmd
+{
+    uint16_t cmd_id;
+    uint16_t session_id;
+    uint8_t ack_result;
+    union anon_union_conflict2c9b_for_field_3 field_3;
+    undefined field4_0x16;
+    undefined field5_0x17;
+    void (*call_back_handler)(struct __gs_camera_cmd *);
+};
+
+struct bridge_io_pkt
+{
+    uint32_t paddr;
+    uint32_t size;
+    uint8_t notify;
+    undefined field3_0x9;
+    undefined field4_0xa;
+    undefined field5_0xb;
+};
+
+struct gs_lv_pkt
+{
+    void *align_vaddr;
+    int align_size;
+    void *vaddr;
+    void *payload_vaddr;
+    uint32_t payload_size;
+    bridge_io_pkt_t pkt;
+};
+
+struct uav_gimbal_ops
+{
+    int (*ctrl_start)(void *);
+    int (*ctrl_racing_start)(void *);
+    int (*ctrl_stop)(void *);
+    int (*reset_init_value)(void *);
+    int (*turndown_start)(void *);
+    int (*turndown_stop)(void *);
+    int (*set_workmode)(void *, uint8_t);
+    int (*ctrl_set_racing_pitch_offset)(void *, int16_t);
+    int (*ctrl_set_racing_yaw_offset)(void *, int16_t);
+    int (*ctrl_set_racing_pitch_sense)(void *, float);
+    int (*ctrl_set_racing_yaw_sense)(void *, float);
+    int (*ctrl_get_state)(void *, uint8_t *);
+};
+
+struct duss_hal_icc_config_t
+{
+    enum duss_hal_icc_role_t role;
+    enum duss_hal_icc_shm_type_t shm_type;
+    uint32_t shm_size;
 };
 
 struct RcOverride
@@ -2129,76 +4896,109 @@ struct RcOverride
     float quality_factor;
 };
 
-struct ion_info
+struct uav_camera_ops
 {
-    duss_hal_obj_handle_t mem_obj;
-    struct duss_hal_mem_config_t mem_cfg;
-    struct duss_hal_mem_param_t mem_param;
-    duss_hal_mem_handle_t ion_buf;
-    void *ion_virt_addr;
-    uint32_t ion_len;
-    struct duss_osal_mutex_handle_t *ion_mutex;
-    uint32_t start_addr;
-    uint32_t stop_addr;
-    uint32_t size_waste;
+    int (*send_camera_cmd)(void *, gs_camera_cmd_t *, _Bool);
+    int (*set_camera_param)(void *, uint8_t, uint8_t);
+    int (*get_rec_time)(void *, int *, int *);
 };
 
-struct AVClass
+struct duss_event_cmd_desc
 {
-    char *class_name;
-    char *(*item_name)(void *);
-    struct AVOption *option;
-    int version;
-    int log_level_offset_offset;
-    int parent_log_context_offset;
-    void *(*child_next)(void *, void *);
-    AVClass *(*child_class_next)(struct AVClass *);
-    enum AVClassCategory category;
-    AVClassCategory (*get_category)(void *);
-    int (*query_ranges)(struct AVOptionRanges **, void *, char *, int);
+    duss_result_t (*req_cb)(struct duss_event_client *, duss_event_t *, void *);
+    duss_result_t (*ack_cb)(struct duss_event_client *, duss_event_t *, void *);
+    uint32_t flags;
 };
 
-struct duss_hal_obj
+struct cJSON
 {
-    struct duss_hal_obj_dev_t dev;
-    void *dev_class;
-    void *dev_priv;
+    struct cJSON *next;
+    struct cJSON *prev;
+    struct cJSON *child;
+    int type;
+    char *valuestring;
+    int valueint;
+    double valuedouble;
+    char *string;
+    undefined field8_0x24;
+    undefined field9_0x25;
+    undefined field10_0x26;
+    undefined field11_0x27;
 };
 
-struct AVPacketSideData
+struct vr_device_ops
 {
-    uint8_t *data;
-    int size;
-    enum AVPacketSideDataType type;
+    int (*get_video_scale)(void *, float *);
+    int (*set_video_scale)(void *, float);
+    int (*adjust_fov)(void *, uint32_t, int16_t, int16_t);
+    int (*set_brightness_value)(void *, uint8_t);
+    int (*get_brightness_value)(void *, uint8_t *);
+    int (*get_device_volume)(void *, uint8_t, uint32_t *);
+    int (*set_device_volume)(void *, uint8_t, uint32_t);
+    int (*calibrate_imu)(char *);
+    int (*initialize_imu)(void *, ...);
+    int (*destroy_imu)(void *, ...);
+    int (*start_imu)(void *, ...);
+    int (*stop_imu)(void *, ...);
+    int (*get_imu_init_status)(void *, ...);
+    int (*get_imu_attitude)(float *);
+    int (*format_sd)(void *);
+    int (*get_sd_info)(void *, gs_local_sd_info_t *);
+    int (*get_battery_info)(void *, DUSS_MSG_RC_BAT_INFO_t *);
+    int (*get_device_active_state)(void *, int);
+    int (*get_upgrade_info)(void *, _Bool *, uint8_t *, uint8_t *);
+    int (*av_in_us_get_brightness)(void *, uint8_t *);
+    int (*av_in_us_set_brightness)(void *, uint8_t);
+    int (*av_in_us_get_saturation)(void *, uint8_t *);
+    int (*av_in_us_set_saturation)(void *, uint8_t);
+    int (*reset_user_settings)(void *);
+    int (*event_tracking)(void *, int32_t, uint8_t, uint8_t);
+    void (*get_flight_stat)(uint8_t *);
+    void (*set_flight_stat)(uint8_t);
+    int (*watermarker_us_get_flag)(void *, uint8_t *);
+    int (*watermarker_us_set_flag)(void *, uint8_t);
+    int (*watermarker_us_reset)(void *);
 };
 
-struct pl_muxer_t
+struct pl_decoder_itf_t
 {
-    struct pl_muxer_itf_t *itf;
-    void *context;
-    void *me;
+    int (*create)(pl_decoder_handle_t *, void *, void *);
+    int (*destroy)(pl_decoder_handle_t);
+    int (*init)(pl_decoder_handle_t);
+    int (*config)(pl_decoder_handle_t, void *);
+    int (*prepare)(pl_decoder_handle_t);
+    int (*release)(pl_decoder_handle_t);
+    int (*decode)(pl_decoder_handle_t, void *, uint32_t, void *, uint32_t *);
+    int (*push_frame)(pl_decoder_handle_t, void *, uint32_t);
+    int (*set_input_datacb)(pl_decoder_handle_t, void *, input_data_cb);
+    int (*set_output_datacb)(pl_decoder_handle_t, void *, output_data_cb);
 };
 
-struct __gs_local_sd_info
+struct duss_event_ack_identify
 {
-    duss_storage_client_t *sdcard_cli;
-    _Bool sd_insert;
-    undefined field2_0x5;
-    undefined field3_0x6;
-    undefined field4_0x7;
-    sd_file_type_t sd_type;
-    uint32_t sd_total_kbytes;
-    uint32_t sd_free_kbytes;
-    uint32_t sd_minfree_kbytes;
-    uint8_t sd_status;
-    uint8_t sd_formatting;
-    _Bool sd_init;
-    undefined field12_0x1b;
-    struct duss_osal_mutex_handle_t *sd_status_mutex;
-    gs_storage_listener_t *storage_listener;
-    gs_sd_listener_t *sd_listener;
-    gs_meta_listener_t *meta_listener;
-    gs_playback_listener_t *pb_listener;
+    duss_msg_id_t msg_id;
+    uint16_t peer_host;
+    uint16_t seq_id;
+    uint16_t valid;
+    undefined field4_0xa;
+    undefined field5_0xb;
+    void *buffer_ptr;
+    uint32_t buffer_size;
+};
+
+struct vcm_ops
+{
+    int (*register_channel_switch_callback)(void *, gs_video_channel_switch_callback_t, void *);
+    int (*register_channel_push_callback)(void *, gs_video_channel_push_callback_t, void *);
+    int (*query_current_channel)(void *, gs_video_channel_id_t *);
+    int (*enable_channel)(void *, gs_main_channel_id_t);
+    int (*disable_channel)(void *, gs_main_channel_id_t);
+    int (*enable_sub_channel)(void *, gs_video_channel_id_t *);
+    int (*disable_sub_channel)(void *, gs_video_channel_id_t *);
+    int (*local_playback_on)(void *, char *);
+    int (*local_playback_off)(void *);
+    int (*rc_setting_on)(void *);
+    int (*rc_setting_off)(void *);
 };
 
 struct AVOptionRange
@@ -2219,90 +5019,16 @@ struct AVOptionRange
     undefined field13_0x2f;
 };
 
-struct gs_storage_listener
+struct debug_osd_item
 {
-    void *ctx;
-    int (*event_cb)(void *, storage_event_t);
+    char *name;
+    int value;
 };
 
-struct gs_lv_transcode
+struct debug_cam_osd_info
 {
-    ion_info_t *ion_info;
-    struct duss_osal_mutex_handle_t *rec_mutex;
-    record_state_t cur_state;
-    record_state_t tgt_state;
-    _Bool b_rec_running;
-    undefined field5_0x11;
-    undefined field6_0x12;
-    undefined field7_0x13;
-    struct duss_osal_task_handle_t *rec_thread;
-    uint8_t *lv_rec_state;
-    gs_local_sd_info_t *sd_info;
-    gs_sd_listener_t sd_listener;
-    gs_usb_listener_t usb_listener;
-    gs_media_cmd_chnl_t *mcc;
-    int dmi_data_fd;
-    int file_idx;
-    char file_name[128];
-    struct AVCodecContext *avcodec_ctx;
-    p1_muxer_handle_t muxer;
-    record_mode_t rec_mode;
-    int video_stream_index;
-    undefined field21_0xcc;
-    undefined field22_0xcd;
-    undefined field23_0xce;
-    undefined field24_0xcf;
-    int64_t cur_rec_time;
-    char *sps_buf;
-    uint32_t sps_len;
-    struct duss_osal_mutex_handle_t *video_list_mutex;
-    struct duss_list_head video_list;
-    int num_frames;
-    _Bool b_running;
-    _Bool b_eos;
-    undefined field33_0xf2;
-    undefined field34_0xf3;
-    struct duss_osal_task_handle_t *task_rx;
-    uint32_t frames_received;
-    uint32_t frames_write;
-    uint32_t last_key_frm_idx;
-    uint32_t last_frame_idx;
-    _Bool b_wrf_running;
-    undefined field41_0x109;
-    undefined field42_0x10a;
-    undefined field43_0x10b;
-    FILE *p_file;
-    struct duss_osal_task_handle_t *task_wrf;
-    int first_idx_in_file;
-    _Bool b_pending_new_file;
-    _Bool b_avin_recording;
-    undefined field49_0x11a;
-    undefined field50_0x11b;
-    undefined field51_0x11c;
-    undefined field52_0x11d;
-    undefined field53_0x11e;
-    undefined field54_0x11f;
-    int64_t cur_rec_time_ms;
-    char srt_file_name[128];
-    _Bool b_srt_record_running;
-    _Bool b_srt_switch_new_file;
-    undefined field59_0x1aa;
-    undefined field60_0x1ab;
-    FILE *p_srt_file;
-    struct duss_osal_task_handle_t *task_srt_record;
-    undefined field63_0x1b4;
-    undefined field64_0x1b5;
-    undefined field65_0x1b6;
-    undefined field66_0x1b7;
-};
-
-struct gs_media_cmd_chnl
-{
-    int chnl_fd;
-    _Bool init;
-    undefined field2_0x5;
-    undefined field3_0x6;
-    undefined field4_0x7;
+    debug_osd_item_t items[26];
+    int n_items;
 };
 
 struct AVPanScan
@@ -2313,42 +5039,1015 @@ struct AVPanScan
     int16_t position[3][2];
 };
 
-struct AVCodec
-{
-    char *name;
-    char *long_name;
-    enum AVMediaType type;
-    enum AVCodecID id;
-    int capabilities;
-    struct AVRational *supported_framerates;
-    enum AVPixelFormat *pix_fmts;
-    int *supported_samplerates;
-    enum AVSampleFormat *sample_fmts;
-    uint64_t *channel_layouts;
-    uint8_t max_lowres;
-    undefined field11_0x29;
-    undefined field12_0x2a;
-    undefined field13_0x2b;
-    struct AVClass *priv_class;
-    struct AVProfile *profiles;
-    int priv_data_size;
-    struct AVCodec *next;
-    int (*init_thread_copy)(struct AVCodecContext *);
-    int (*update_thread_context)(struct AVCodecContext *, struct AVCodecContext *);
-    struct AVCodecDefault *defaults;
-    void (*init_static_data)(struct AVCodec *);
-    int (*init)(struct AVCodecContext *);
-    int (*encode_sub)(struct AVCodecContext *, uint8_t *, int, struct AVSubtitle *);
-    int (*encode2)(struct AVCodecContext *, struct AVPacket *, struct AVFrame *, int *);
-    int (*decode)(struct AVCodecContext *, void *, int *, struct AVPacket *);
-    int (*close)(struct AVCodecContext *);
-    void (*flush)(struct AVCodecContext *);
-};
-
 struct AVProfile
 {
     int profile;
     char *name;
+};
+
+struct loc_channel_addr
+{
+    uint16_t direct_host;
+};
+
+struct __gs_common_cmd
+{
+    duss_msg_id_t msg_id;
+    uint16_t receiver_id;
+    uint16_t session_id;
+    uint8_t ack_result;
+    undefined field4_0x9;
+    undefined field5_0xa;
+    undefined field6_0xb;
+    uint8_t *msg_buf;
+    uint32_t msg_len;
+    uint8_t *resp_msg_buf;
+    uint32_t resp_msg_len;
+    void (*call_back_handler)(struct __gs_common_cmd *);
+};
+
+struct duss_hal_mem_config_t
+{
+    uint32_t reserved;
+};
+
+struct wl_channel_addr
+{
+    char *ifx;
+    uint16_t loc_port;
+    undefined field2_0x6;
+    undefined field3_0x7;
+    char *address;
+    uint16_t rmt_port;
+    uint16_t mtu;
+    _Bool is_server;
+    duss_wl_prot_type_t protocol;
+    duss_wl_prio_t priority;
+    undefined field10_0x13;
+    int flags;
+};
+
+struct AVDeviceCapabilitiesQuery
+{
+};
+
+struct __sbuf
+{
+    uchar *_base;
+    int _size;
+};
+
+struct vdec_video_file_info
+{
+    uint32_t strm_type;
+    uint32_t total_time;
+    uint32_t frame_interval;
+    uint32_t fps_numerator;
+    uint32_t fps_denorm;
+    uint32_t width;
+    uint32_t height;
+    int32_t rotation;
+    enum DUSS_FILE_FORMAT video_format;
+};
+
+struct fd_set
+{
+    ulong fds_bits[32];
+};
+
+struct duss_mb_client
+{
+    uint16_t this_host;
+    undefined field1_0x2;
+    undefined field2_0x3;
+    duss_result_t (*msg_cb)(struct duss_mb_client *, uint16_t, uint16_t, duss_msg_attrib_t, duss_msg_id_t, uint8_t *, int32_t, void *);
+    void *msg_cb_userdata;
+    duss_result_t (*filter_cb)(struct duss_mb_client *, struct duss_mb_route_item_t *, uint16_t, uint16_t, uint16_t, duss_msg_attrib_t, duss_msg_id_t, uint8_t *, int32_t, void *);
+    void *filter_cb_userdata;
+    struct duss_mb_route_table_t *route_table;
+    struct duss_osal_mutex_handle_t *lock;
+    struct duss_osal_task_handle_t *task;
+    int fd_max;
+    struct fd_set fds;
+    _Bool finish;
+    undefined field13_0xa5;
+    undefined field14_0xa6;
+    undefined field15_0xa7;
+    int channel_num;
+    void *channel[32];
+    int target_num;
+    void *target[64];
+};
+
+struct AVPacket
+{
+    struct AVBufferRef *buf;
+    undefined field1_0x4;
+    undefined field2_0x5;
+    undefined field3_0x6;
+    undefined field4_0x7;
+    int64_t pts;
+    int64_t dts;
+    uint8_t *data;
+    int size;
+    int stream_index;
+    int flags;
+    struct AVPacketSideData *side_data;
+    int side_data_elems;
+    int duration;
+    void (*destruct)(struct AVPacket *);
+    void *priv;
+    undefined field16_0x3c;
+    undefined field17_0x3d;
+    undefined field18_0x3e;
+    undefined field19_0x3f;
+    int64_t pos;
+    int64_t convergence_duration;
+    _Bool is_last_section;
+    undefined field23_0x51;
+    undefined field24_0x52;
+    undefined field25_0x53;
+    int32_t nal_total_size;
+};
+
+struct icc_channel_addr
+{
+    char *obj_name;
+    char *snd_chn;
+    char *rcv_chn;
+    struct duss_hal_icc_config_t cfg;
+};
+
+struct duss_mb_route_table_t
+{
+    void *priv_data;
+    int target_size;
+    struct duss_mb_route_item_t *targets[128];
+};
+
+struct AVCodecInternal
+{
+};
+
+struct pl_decoder_t
+{
+    struct pl_decoder_itf_t *itf;
+    void *context;
+    struct AVRational time_base;
+    void *me;
+    _Bool running;
+    undefined field5_0x15;
+    undefined field6_0x16;
+    undefined field7_0x17;
+    struct duss_osal_msgq_handle_t *packet_queue;
+    struct duss_osal_msgq_handle_t *frame_queue;
+    struct duss_osal_task_handle_t *decode_task;
+};
+
+struct gs_local_panorama_info
+{
+    char file_path[256];
+    uint8_t file_type;
+    undefined field2_0x101;
+    undefined field3_0x102;
+    undefined field4_0x103;
+    int gfxLayerFd;
+};
+
+struct duss_hal_i2c_config_t
+{
+    int baudrate;
+    duss_i2c_addr_len_t addr_len;
+    undefined field2_0x5;
+    undefined field3_0x6;
+    undefined field4_0x7;
+};
+
+struct duss_hal_storage_params
+{
+    enum duss_storage_client_type_t client_id;
+    void *user_data;
+    void (*callback)(struct duss_hal_storage_info *, void *);
+};
+
+struct AVBufferRef
+{
+    struct AVBuffer *buffer;
+    uint8_t *data;
+    int size;
+};
+
+struct sem_t
+{
+    uint count;
+};
+
+struct duss_osal_mutex_handle_t
+{
+    struct duss_osal_mutex_attrib_t attrib;
+    struct sem_t sema;
+};
+
+struct stick_mode_self_define_t
+{
+    uint8_t ch_reverse : 1;
+    uint8_t stick_channel : 7;
+};
+
+struct rc_set_stick_mode_pack_t
+{
+    uint8_t stick_mode;
+    struct stick_mode_self_define_t ch_setup[0];
+};
+
+struct duss_osal_task_attrib_t
+{
+    char *name;
+    duss_osal_task_entry_t entry;
+    void *param;
+    enum duss_osal_priority_t priority;
+    uint32_t stack_size;
+    uint32_t time_slice;
+    _Bool detached;
+    undefined field7_0x19;
+    undefined field8_0x1a;
+    undefined field9_0x1b;
+    uint32_t affinity_mask;
+};
+
+struct SwrContext
+{
+};
+
+struct AVHWAccel
+{
+    char *name;
+    enum AVMediaType type;
+    enum AVCodecID id;
+    enum AVPixelFormat pix_fmt;
+    int capabilities;
+    struct AVHWAccel *next;
+    int (*alloc_frame)(struct AVCodecContext *, struct AVFrame *);
+    int (*start_frame)(struct AVCodecContext *, uint8_t *, uint32_t);
+    int (*decode_slice)(struct AVCodecContext *, uint8_t *, uint32_t);
+    int (*end_frame)(struct AVCodecContext *);
+    int frame_priv_data_size;
+    void (*decode_mb)(struct MpegEncContext *);
+    int (*init)(struct AVCodecContext *);
+    int (*uninit)(struct AVCodecContext *);
+    int priv_data_size;
+};
+
+struct netlink_channel_addr
+{
+    uint16_t host_pid;
+    uint16_t group;
+    uint16_t target_pid;
+};
+
+struct duss_hal_uart_config_t
+{
+    int baudrate;
+    duss_uart_parity_t parity;
+    duss_uart_stopbit_t stopbit;
+    duss_uart_wordlen_t wordlen;
+    undefined field4_0x7;
+};
+
+struct uart_channel_addr
+{
+    char *obj_name;
+    struct duss_hal_uart_config_t cfg;
+};
+
+struct usb_channel_addr
+{
+    char *device;
+    uint32_t vid;
+    uint32_t pid;
+    uint16_t interface;
+    uint16_t altsetting;
+    uint8_t in_ep;
+    uint8_t out_ep;
+    undefined field7_0x12;
+    undefined field8_0x13;
+};
+
+struct duss_hal_spi_config_t
+{
+    int mode;
+    int baudrate;
+    int lsb_first;
+    int bits_per_word;
+};
+
+struct spi_channel_addr
+{
+    char *obj_name;
+    struct duss_hal_spi_config_t cfg;
+};
+
+struct duss_hal_can_config_t
+{
+    duss_mb_can_chip_t chip;
+    undefined field1_0x1;
+    undefined field2_0x2;
+    undefined field3_0x3;
+    uint32_t baudrate;
+    duss_mb_host_id_t target;
+    undefined field6_0xa;
+    undefined field7_0xb;
+    uint32_t rx;
+    uint32_t tx;
+};
+
+struct can_channel_addr
+{
+    char *obj_name;
+    struct duss_hal_can_config_t cfg;
+};
+
+struct duss_hal_bulk_config_t
+{
+};
+
+struct bulk_channel_addr
+{
+    char *obj_name;
+    struct duss_hal_bulk_config_t cfg;
+};
+
+struct i2c_channel_addr
+{
+    char *obj_name;
+    struct duss_hal_i2c_config_t cfg;
+};
+
+union anon_union_conflict1232_for_channel
+{
+    struct loc_channel_addr local;
+    struct ip_channel_addr ip;
+    struct wl_channel_addr wl;
+    struct uart_channel_addr uart;
+    struct can_channel_addr can;
+    struct i2c_channel_addr i2c;
+    struct spi_channel_addr spi;
+    struct hpi_channel_addr hpi;
+    struct usb_channel_addr usb;
+    struct usbacc_channel_addr usbacc;
+    struct icc_channel_addr icc;
+    struct netlink_channel_addr netlink;
+    struct bulk_channel_addr bulk;
+};
+
+struct AVPicture
+{
+    uint8_t *data[8];
+    int linesize[8];
+};
+
+struct debug_cp_osd_info
+{
+    debug_osd_item_t items[4];
+    int n_items;
+};
+
+struct AVDictionary
+{
+};
+
+struct duss_hal_mem_param_t
+{
+    uint32_t reserved;
+};
+
+struct ion_info
+{
+    duss_hal_obj_handle_t mem_obj;
+    struct duss_hal_mem_config_t mem_cfg;
+    struct duss_hal_mem_param_t mem_param;
+    duss_hal_mem_handle_t ion_buf;
+    void *ion_virt_addr;
+    uint32_t ion_len;
+    struct duss_osal_mutex_handle_t *ion_mutex;
+    uint32_t start_addr;
+    uint32_t stop_addr;
+    uint32_t size_waste;
+};
+
+struct audio_resampler_t
+{
+    struct SwrContext *swr_ctx;
+    int src_rate;
+    int dst_rate;
+    int src_nb_channels;
+    int dst_nb_channels;
+    enum AVSampleFormat src_sample_fmt;
+    enum AVSampleFormat dst_sample_fmt;
+};
+
+struct pcm
+{
+    int fd;
+    uint flags;
+    uint running : 1;
+    uint prepared : 1;
+    undefined field4_0x9;
+    undefined field5_0xa;
+    undefined field6_0xb;
+    int underruns;
+    uint buffer_size;
+    uint boundary;
+    char error[128];
+    struct pcm_config config;
+    struct snd_pcm_mmap_status *mmap_status;
+    struct snd_pcm_mmap_control *mmap_control;
+    struct snd_pcm_sync_ptr *sync_ptr;
+    void *mmap_buffer;
+    uint noirq_frames_per_msec;
+    int wait_for_avail_min;
+    struct timespec tstamp;
+    int (*ev_callback)(int, void *);
+    void *ev_params;
+    char ev_running;
+    undefined field22_0xed;
+    undefined field23_0xee;
+    undefined field24_0xef;
+    pthread_t ev_thread;
+    char chg_3le_to_le;
+    undefined field27_0xf5;
+    undefined field28_0xf6;
+    undefined field29_0xf7;
+    char *buffer_4le;
+    uint size_4le;
+};
+
+struct duss_mb_filter_t
+{
+    uint16_t source;
+    uint16_t target;
+    duss_msg_id_t msg_id;
+    duss_msg_attrib_t attrib;
+    undefined field4_0xa;
+    undefined field5_0xb;
+};
+
+struct duss_hal_obj_dev_t
+{
+    char *name;
+    duss_hal_state_t obj_state;
+    duss_hal_class_t obj_class;
+    uint16_t obj_index;
+    int32_t obj_refcnt;
+    struct duss_osal_mutex_handle_t *obj_lock;
+    struct duss_osal_mutex_handle_t *app_lock;
+    duss_result_t (*open)(duss_hal_obj_handle_t, void *);
+    duss_result_t (*close)(duss_hal_obj_handle_t);
+    duss_result_t (*set_cfg)(duss_hal_obj_handle_t, void *);
+    duss_result_t (*get_cfg)(duss_hal_obj_handle_t, void *);
+    duss_result_t (*start)(duss_hal_obj_handle_t, void *);
+    duss_result_t (*stop)(duss_hal_obj_handle_t, void *);
+};
+
+struct duss_hal_obj
+{
+    struct duss_hal_obj_dev_t dev;
+    void *dev_class;
+    void *dev_priv;
+};
+
+struct duss_event
+{
+    duss_msg_id_t msg_id;
+    uint16_t peer_host;
+    duss_msg_attrib_t attrib;
+    uint16_t seq_id;
+    undefined field4_0xa;
+    undefined field5_0xb;
+    uint32_t msg_len;
+    uint8_t msg_buf[0];
+};
+
+struct common_cmd_ops
+{
+    int (*send_common_cmd)(void *, gs_common_cmd_t *, _Bool);
+};
+
+struct local_playback_ops
+{
+    int (*open)(void *, char *);
+    int (*close)(void *);
+    int (*stop)(void *);
+    int (*pause)(void *);
+    int (*resume)(void *);
+    int (*seek)(void *, uint32_t);
+    int (*seek_time)(void *, uint32_t);
+    int (*get_duration)(char *, uint32_t *);
+    int (*get_cur_time)(void *, uint32_t *, uint32_t *);
+    int (*get_state)(void *, uint32_t *);
+    int (*get_file_info)(char *, vdec_video_file_info_t *);
+    int (*is_playing)(void *, _Bool *);
+    int (*delete_file)(char *);
+};
+
+struct rc_ops
+{
+    int (*get_version)(void *, char *, char *, int8_t *);
+    int (*get_version_async)(void *);
+    int (*set_subtrim)(void *, uint8_t, int16_t);
+    int (*set_subtrim_async)(void *, uint8_t, int16_t);
+    int (*get_subtrim)(void *, struct rc_set_all_st_t *, int8_t *);
+    int (*get_subtrim_async)(void *);
+    int (*set_reverse)(void *, uint8_t, uint8_t);
+    int (*get_reverse)(void *, union rc_set_reverse_t *, int8_t *);
+    int (*get_reverse_async)(void *);
+    int (*set_endpoint)(void *, uint8_t, uint8_t, uint8_t);
+    int (*set_endpoint_async)(void *, uint8_t, uint8_t, uint8_t);
+    int (*get_endpoint)(void *, struct rc_set_all_ep_t *, int8_t *);
+    int (*get_endpoint_async)(void *);
+    int (*set_func_mode)(void *, uint8_t, uint8_t, uint8_t);
+    int (*get_func_mode)(void *, struct rc_set_function_pack_t *);
+    int (*set_stick_mode)(void *, uint8_t);
+    int (*get_stick_mode)(void *, struct rc_set_stick_mode_pack_t *, int8_t *);
+    int (*get_stick_mode_ext)(void *, uint8_t *);
+    int (*get_stick_mode_async)(void *);
+    int (*set_stick_cali)(void *, uint8_t, uint8_t, uint8_t *);
+    int (*get_stick_cali)(void *, uint8_t, int8_t *, int8_t *, int8_t *, int8_t *);
+    int (*set_warning)(void *, struct rc_set_warning_mode_pack_t);
+    int (*get_warning)(void *, struct rc_set_warning_mode_pack_t *);
+    int (*monitor)(void *, struct rc_monitor_pack_t *);
+    int (*reset_all_get_status)(void *);
+    int (*reset_default_async)(void *, uint8_t);
+    uint8_t (*get_lock_state)(void *);
+    uint8_t (*get_link_state)(void *);
+};
+
+struct __gs_gui_config
+{
+    gs_queue_t *osd_gen_data_queue;
+    gs_queue_t *osd_home_data_queue;
+    gs_queue_t *file_del_queue;
+    gs_queue_t *camera_stat_queue;
+    gs_queue_t *camera_cap_param_queue;
+    gs_queue_t *camera_pb_param_queue;
+    gs_queue_t *camera_file_info_queue;
+    gs_queue_t *camera_dcf_abstract_queue;
+    gs_queue_t *camera_fov_param_queue;
+    gs_queue_t *rc_bat_stat_queue;
+    gs_queue_t *signal_quality_queue;
+    gs_queue_t *uav_bat_common_info_queue;
+    gs_queue_t *sdr_wl_env_queue;
+    gs_queue_t *sdr_uav_data_queue;
+    gs_queue_t *sdr_gnd_data_queue;
+    gs_queue_t *rc_param_queue;
+    gs_queue_t *rc_pushed_gps_queue;
+    gs_queue_t *racing_drone_fc_osd_queue;
+    _Bool *touchpadLockState;
+    void *ctx;
+    ext_fc_ops_t ext_fc_ops;
+    vr_device_ops_t vdev_ops;
+    local_playback_ops_t local_pb_ops;
+    uav_camera_ops_t uav_cam_ops;
+    uav_gimbal_ops_t gimbal_ops;
+    modem_ops_t modem_ops;
+    rc_ops_t rc_ops;
+    vcm_ops_t vcm_ops;
+    common_cmd_ops_t cmn_cmd_ops;
+    int (*get_codec_debug_osd_info)(void *, debug_codec_osd_info_t *);
+    int (*get_cam_debug_osd_info)(void *, debug_cam_osd_info_t *);
+    int (*get_temp_debug_osd_info)(void *, debug_temp_osd_info_t *);
+    int (*get_uav_max_temp)(void *, int32_t *);
+    int (*get_cp_debug_osd_info)(void *, debug_cp_osd_info_t *);
+    int (*set_racing_enc_strategy)(void *, uint8_t);
+    int (*is_camera_in_record)(void *, int *);
+    int (*get_cparm_version)(void *, char *);
+    int (*get_dsp_version)(void *, char *);
+    int (*get_flight_time)(void *, uint64_t *);
+    int (*get_arm_status)(void *, uint8_t *);
+    int (*clear_adb_log_info)(void *);
+    int (*reset_camera_param)(void *);
+    int (*set_low_power_mode)(void *, _Bool);
+    int (*get_uav_version)(void *, char *, char *);
+    int (*get_uav_hardware_version)(void *, char *);
+    int (*get_uav_power_status)(void *, uint8_t *, uint8_t *);
+    int (*get_uav_camera_type)(void *, uint8_t *);
+    int (*get_liveview_fps)(void *, uint8_t *);
+    int (*fbdev_open)(void);
+    int (*fbdev_disp_frame)(int);
+    int (*fbdev_close)(void);
+    int (*record_liveview)(void *, _Bool);
+    int (*get_liveview_state)(void *, int *);
+    record_mode_t (*get_liveview_record_mode)(void *);
+    int (*set_liveview_record_mode)(void *, record_mode_t);
+    int (*get_liveview_record_enable)(void *);
+    int (*set_liveview_record_enable)(void *, _Bool, enum Record_sender);
+    int (*get_liveview_record_time)(void *, int *);
+    int (*enable_audio_liveview)(void *, _Bool);
+    int (*get_frame_delay_e2e)(void *, uint16_t *);
+    int (*get_chnl_status)(void *, uint16_t *);
+    int (*get_pigeon_battery_info)(void *, gs_battery_voltage_t *);
+    int (*get_sd_status)(void *, int, uint8_t *, uint32_t *, uint32_t *);
+    int (*play_pwm_buzzer)(void *, int, int, int);
+    int (*buzzer_enable_bat)(void *, _Bool);
+};
+
+struct AVCodecParserContext
+{
+    void *priv_data;
+    struct AVCodecParser *parser;
+    int64_t frame_offset;
+    int64_t cur_offset;
+    int64_t next_frame_offset;
+    int pict_type;
+    int repeat_pict;
+    int64_t pts;
+    int64_t dts;
+    int64_t last_pts;
+    int64_t last_dts;
+    int fetch_timestamp;
+    int cur_frame_start_index;
+    int64_t cur_frame_offset[4];
+    int64_t cur_frame_pts[4];
+    int64_t cur_frame_dts[4];
+    int flags;
+    undefined field17_0xb4;
+    undefined field18_0xb5;
+    undefined field19_0xb6;
+    undefined field20_0xb7;
+    int64_t offset;
+    int64_t cur_frame_end[4];
+    int key_frame;
+    undefined field24_0xe4;
+    undefined field25_0xe5;
+    undefined field26_0xe6;
+    undefined field27_0xe7;
+    int64_t convergence_duration;
+    int dts_sync_point;
+    int dts_ref_dts_delta;
+    int pts_dts_delta;
+    undefined field32_0xfc;
+    undefined field33_0xfd;
+    undefined field34_0xfe;
+    undefined field35_0xff;
+    int64_t cur_frame_pos[4];
+    int64_t pos;
+    int64_t last_pos;
+    int duration;
+    enum AVFieldOrder field_order;
+    enum AVPictureStructure picture_structure;
+    int output_picture_number;
+};
+
+struct duss_osal_msgq_attrib_t
+{
+    char *name;
+    uint32_t buf_size;
+};
+
+struct duss_osal_msgq_handle_t
+{
+    struct duss_osal_msgq_attrib_t attrib;
+    struct pthread_mutex_t r_mutex;
+    struct pthread_mutex_t s_mutex;
+    struct pthread_cond_t r_cond;
+    struct pthread_cond_t s_cond;
+    uint32_t buf_size;
+    uint32_t head;
+    uint32_t tail;
+    uint8_t *buffer;
+};
+
+struct duss_mb_route_item_t
+{
+    uint8_t status;
+    char name[16];
+    undefined field2_0x11;
+    uint16_t target;
+    duss_mb_channel_t access_channel;
+    uint8_t distance;
+    duss_mb_pack_ver_t pack_ver;
+    undefined field7_0x17;
+    union anon_union_conflict1232_for_channel channel;
+    int filter_size;
+    struct duss_mb_filter_t *filters;
+};
+
+struct rc_monitor_pack_t
+{
+    uint8_t channel_num;
+    uint16_t channel_val[0];
+};
+
+struct AVFormatInternal
+{
+};
+
+struct debug_osd_info
+{
+    debug_osd_item_t items[15];
+    int n_items;
+};
+
+struct AVOptionRanges
+{
+    struct AVOptionRange **range;
+    int nb_ranges;
+    int nb_components;
+};
+
+struct snd_pcm_sync_ptr
+{
+};
+
+union anon_union_conflictac8f4_for_default_val
+{
+    int64_t i64;
+    double dbl;
+    char *str;
+    struct AVRational q;
+};
+
+struct gs_playback_listener
+{
+    void *ctx;
+    int (*event_cb)(void *, playback_event_t);
+};
+
+struct gs_local_video_info
+{
+    char video_path[256];
+    char audio_path[256];
+};
+
+union anon_union_conflict3b31_for_field_1
+{
+    _Bool plugin;
+    uint8_t cam_workmode;
+    uint8_t cam_pbmode;
+    uint8_t cam_model;
+    _Bool wl_link;
+    gs_main_channel_id_t chnl_id;
+    gs_video_channel_id_t sub_chnl_id;
+    gs_local_video_info_t video_info;
+    uint32_t video_index;
+    _Bool is_pal;
+    gs_local_panorama_info_t pano_info;
+};
+
+struct gs_video_channel_message
+{
+    enum gs_video_channel_message_id_t msg_id;
+    union anon_union_conflict3b31_for_field_1 field_1;
+};
+
+struct snd_pcm_mmap_status
+{
+};
+
+struct audio_dec
+{
+    void *gs_info;
+    void *cb_ctx;
+    int (*cb_func)(void *, dec_event_t);
+    audio_pb_state_t audio_pb_state;
+    int codec_id;
+    int sample_rate;
+    int channels;
+    int sample_fmt;
+    pl_decoder_handle_t hnd;
+    struct pl_decoder_itf_t *itf;
+    _Bool b_running;
+    _Bool b_eos;
+    undefined field12_0x2a;
+    undefined field13_0x2b;
+    struct duss_osal_task_handle_t *thread_dec;
+    _Bool b_aout_running;
+    undefined field16_0x31;
+    undefined field17_0x32;
+    undefined field18_0x33;
+    struct duss_osal_task_handle_t *thread_aout;
+    audio_resampler_ptr resampler;
+    uint8_t *resample_buffer;
+    int resample_buf_size;
+    int frames_received;
+    int frames_decoded;
+    FILE *f_a_out;
+    struct duss_osal_mutex_handle_t *list_mutex;
+    struct duss_list_head frame_list;
+    int num_in_list;
+    struct duss_osal_mutex_handle_t *pcm_mutex;
+    struct duss_list_head pcm_list;
+    int num_pcm;
+    _Bool b_started;
+    undefined field33_0x71;
+    undefined field34_0x72;
+    undefined field35_0x73;
+    struct timespec tstamp;
+    int samples_played;
+    _Bool b_first_frm_sent;
+    undefined field39_0x81;
+    undefined field40_0x82;
+    undefined field41_0x83;
+    undefined field42_0x84;
+    undefined field43_0x85;
+    undefined field44_0x86;
+    undefined field45_0x87;
+    int64_t play_tm_offset_ms;
+    int64_t play_tm_ms;
+};
+
+struct AVCodecDefault
+{
+};
+
+struct AVCodecTag
+{
+};
+
+struct AVProgram
+{
+    int id;
+    int flags;
+    enum AVDiscard discard;
+    uint *stream_index;
+    uint nb_stream_indexes;
+    struct AVDictionary *metadata;
+    int program_num;
+    int pmt_pid;
+    int pcr_pid;
+    undefined field9_0x24;
+    undefined field10_0x25;
+    undefined field11_0x26;
+    undefined field12_0x27;
+    int64_t start_time;
+    int64_t end_time;
+    int64_t pts_wrap_reference;
+    int pts_wrap_behavior;
+    undefined field17_0x44;
+    undefined field18_0x45;
+    undefined field19_0x46;
+    undefined field20_0x47;
+};
+
+struct AVInputFormat
+{
+    char *name;
+    char *long_name;
+    int flags;
+    char *extensions;
+    struct AVCodecTag **codec_tag;
+    struct AVClass *priv_class;
+    char *mime_type;
+    struct AVInputFormat *next;
+    int raw_codec_id;
+    int priv_data_size;
+    int (*read_probe)(struct AVProbeData *);
+    int (*read_header)(struct AVFormatContext *);
+    int (*read_packet)(struct AVFormatContext *, struct AVPacket *);
+    int (*read_close)(struct AVFormatContext *);
+    int (*read_seek)(struct AVFormatContext *, int, int64_t, int);
+    int64_t (*read_timestamp)(struct AVFormatContext *, int, int64_t *, int64_t);
+    int (*read_play)(struct AVFormatContext *);
+    int (*read_pause)(struct AVFormatContext *);
+    int (*read_seek2)(struct AVFormatContext *, int, int64_t, int64_t, int64_t, int);
+    int (*get_device_list)(struct AVFormatContext *, struct AVDeviceInfoList *);
+    int (*create_device_capabilities)(struct AVFormatContext *, struct AVDeviceCapabilitiesQuery *);
+    int (*free_device_capabilities)(struct AVFormatContext *, struct AVDeviceCapabilitiesQuery *);
+};
+
+struct anon_struct_conflict69b3c_for_info
+{
+    int64_t last_dts;
+    int64_t duration_gcd;
+    int duration_count;
+    undefined field3_0x14;
+    undefined field4_0x15;
+    undefined field5_0x16;
+    undefined field6_0x17;
+    int64_t rfps_duration_sum;
+    double *duration_error[2][373];
+    undefined field9_0x24;
+    undefined field10_0x25;
+    undefined field11_0x26;
+    undefined field12_0x27;
+    int64_t codec_info_duration;
+    int64_t codec_info_duration_fields;
+    int found_decoder;
+    undefined field16_0x3c;
+    undefined field17_0x3d;
+    undefined field18_0x3e;
+    undefined field19_0x3f;
+    int64_t last_duration;
+    int64_t fps_first_dts;
+    int fps_first_dts_idx;
+    undefined field23_0x54;
+    undefined field24_0x55;
+    undefined field25_0x56;
+    undefined field26_0x57;
+    int64_t fps_last_dts;
+    int fps_last_dts_idx;
+    undefined field29_0x64;
+    undefined field30_0x65;
+    undefined field31_0x66;
+    undefined field32_0x67;
+};
+
+struct duss_storage_client
+{
+    _Bool start_flag;
+    undefined field1_0x1;
+    undefined field2_0x2;
+    undefined field3_0x3;
+    struct duss_hal_storage_params param;
+    struct duss_hal_storage_info info;
+};
+
+struct duss_osal_timer_handle_t
+{
+    struct duss_osal_timer_attrib_t attrib;
+    pthread_t thread;
+    int32_t repeat_cnt;
+    _Bool suspend;
+    _Bool restart;
+    undefined field5_0x22;
+    undefined field6_0x23;
+    struct sem_t sema;
+    struct sem_t lock;
+    struct timespec saved_time;
+};
+
+struct rc_set_warning_mode_pack_t
+{
+    uint8_t ext_flag : 1;
+    uint8_t warning_tid : 4;
+    uint8_t warning_mode : 3;
+    uint16_t ext_val;
+};
+
+struct AVClass
+{
+    char *class_name;
+    char *(*item_name)(void *);
+    struct AVOption *option;
+    int version;
+    int log_level_offset_offset;
+    int parent_log_context_offset;
+    void *(*child_next)(void *, void *);
+    AVClass *(*child_class_next)(struct AVClass *);
+    enum AVClassCategory category;
+    AVClassCategory (*get_category)(void *);
+    int (*query_ranges)(struct AVOptionRanges **, void *, char *, int);
+};
+
+struct AVIOInterruptCB
+{
+    int (*callback)(void *);
+    void *opaque;
+};
+
+struct AVPacketSideData
+{
+    uint8_t *data;
+    int size;
+    enum AVPacketSideDataType type;
+};
+
+struct product_shm_info
+{
+    uint16_t frm_width;
+    uint16_t frm_height;
+    uint8_t fps;
+    uint8_t enc_strategy;
+    uint16_t lcdc_underflow_cnt;
+    uint32_t enc_sto_frm_dropped;
+    uint32_t enc_lv_frm_dropped;
+    uint32_t mipi_csi_frm_dropped;
+    uint32_t display_frm_dropped;
+    uint64_t audio_pts;
+    uint32_t local_fps_num;
+    uint32_t local_fps_den;
+    uint16_t frame_delay_e2e;
+    uint16_t cam_frame_interval;
+    uint16_t outliner_frame_interval;
+    uint16_t outliner_frame_interval_cnt;
+    uint16_t max_frame_delay_e2e;
+    uint16_t min_frame_delay_e2e;
+    uint16_t avg_frame_delay_e2e;
+    uint16_t if_switch;
+    uint8_t if_change_pipe;
+    uint8_t if_pb_pause;
+    uint8_t liveview_pipeline_running;
+    uint8_t avIn_pipeline_running;
+    uint8_t avIn_stream_type;
+    uint8_t pb_flush;
+    uint8_t disp_pannel_need_reset;
+    undefined field27_0x3f;
+};
+
+struct debug_temp_osd_info
+{
+    debug_osd_item_t items[11];
+    int n_items;
 };
 
 struct pl_muxer_itf_t
@@ -2451,184 +6150,558 @@ struct AVFrame
     undefined field83_0x1df;
 };
 
-typedef struct gs_lv_transcode gs_lv_transcode_t;
+struct vdec_local_player
+{
+    gs_playback_listener_t pb_listener;
+    void *gs_info;
+    uint32_t state;
+    uint32_t cur_time;
+    _Bool b_pending_seek;
+    undefined field5_0x15;
+    undefined field6_0x16;
+    undefined field7_0x17;
+    uint32_t seek_pos;
+    struct AVFormatContext *fmt_ctx;
+    _Bool b_f_eof;
+    undefined field11_0x21;
+    undefined field12_0x22;
+    undefined field13_0x23;
+    int audio_stream_index;
+    audio_dec_t *adec;
+    _Bool b_a_eos;
+    undefined field17_0x2d;
+    undefined field18_0x2e;
+    undefined field19_0x2f;
+    int video_stream_index;
+    cp_vdec_t *vdec;
+    _Bool b_v_eos;
+    _Bool b_running;
+    undefined field24_0x3a;
+    undefined field25_0x3b;
+    struct duss_osal_task_handle_t *task_player;
+    struct duss_osal_mutex_handle_t *vmutex;
+    vdec_video_file_info_t file_info;
+    int64_t first_pts;
+};
 
-typedef struct anon_struct_conflict1d6ff3 anon_struct_conflict1d6ff3;
+struct AVDeviceInfoList
+{
+};
 
-typedef struct duss_osal_sema_attrib_t duss_osal_sema_attrib_t;
+struct AVCodecDescriptor
+{
+    enum AVCodecID id;
+    enum AVMediaType type;
+    char *name;
+    char *long_name;
+    int props;
+    char **mime_types;
+};
 
-struct duss_osal_sema_attrib_t
+struct AVFormatContext
+{
+    struct AVClass *av_class;
+    struct AVInputFormat *iformat;
+    struct AVOutputFormat *oformat;
+    void *priv_data;
+    struct AVIOContext *pb;
+    int ctx_flags;
+    uint nb_streams;
+    struct AVStream **streams;
+    char filename[1024];
+    int64_t start_time;
+    int64_t duration;
+    int bit_rate;
+    uint packet_size;
+    int max_delay;
+    int flags;
+    uint probesize;
+    int max_analyze_duration;
+    uint8_t *key;
+    int keylen;
+    uint nb_programs;
+    struct AVProgram **programs;
+    enum AVCodecID video_codec_id;
+    enum AVCodecID audio_codec_id;
+    enum AVCodecID subtitle_codec_id;
+    uint max_index_size;
+    uint max_picture_buffer;
+    uint nb_chapters;
+    struct AVChapter **chapters;
+    struct AVDictionary *metadata;
+    int64_t start_time_realtime;
+    int fps_probe_size;
+    int error_recognition;
+    struct AVIOInterruptCB interrupt_callback;
+    int debug;
+    undefined field34_0x494;
+    undefined field35_0x495;
+    undefined field36_0x496;
+    undefined field37_0x497;
+    int64_t max_interleave_delta;
+    int strict_std_compliance;
+    int event_flags;
+    int max_ts_probe;
+    int avoid_negative_ts;
+    int ts_id;
+    int audio_preload;
+    int max_chunk_duration;
+    int max_chunk_size;
+    int use_wallclock_as_timestamps;
+    int avio_flags;
+    enum AVDurationEstimationMethod duration_estimation_method;
+    undefined field50_0x4cc;
+    undefined field51_0x4cd;
+    undefined field52_0x4ce;
+    undefined field53_0x4cf;
+    int64_t skip_initial_bytes;
+    uint correct_ts_overflow;
+    int seek2any;
+    int flush_packets;
+    int probe_score;
+    int format_probesize;
+    char *codec_whitelist;
+    char *format_whitelist;
+    struct AVPacketList *packet_buffer;
+    struct AVPacketList *packet_buffer_end;
+    undefined field64_0x4fc;
+    undefined field65_0x4fd;
+    undefined field66_0x4fe;
+    undefined field67_0x4ff;
+    int64_t data_offset;
+    struct AVPacketList *raw_packet_buffer;
+    struct AVPacketList *raw_packet_buffer_end;
+    struct AVPacketList *parse_queue;
+    struct AVPacketList *parse_queue_end;
+    int raw_packet_buffer_remaining_size;
+    undefined field74_0x51c;
+    undefined field75_0x51d;
+    undefined field76_0x51e;
+    undefined field77_0x51f;
+    int64_t offset;
+    struct AVRational offset_timebase;
+    struct AVFormatInternal *internal;
+    int io_repositioned;
+    struct AVCodec *video_codec;
+    struct AVCodec *audio_codec;
+    struct AVCodec *subtitle_codec;
+    int metadata_header_padding;
+    void *opaque;
+    int (*control_message_cb)(struct AVFormatContext *, int, void *, size_t);
+    int64_t output_ts_offset;
+    int64_t max_analyze_duration2;
+    int64_t probesize2;
+    uint8_t *dump_separator;
+    undefined field92_0x56c;
+    undefined field93_0x56d;
+    undefined field94_0x56e;
+    undefined field95_0x56f;
+};
+
+struct duss_event_client
+{
+    uint16_t this_host;
+    undefined field1_0x2;
+    undefined field2_0x3;
+    duss_mb_client_handle_t mb_client_obj;
+    struct duss_osal_msgq_handle_t *msgq;
+    struct duss_osal_task_handle_t *task;
+    struct duss_osal_mutex_handle_t *wait_ack_mutex;
+    struct duss_osal_event_handle_t *wait_ack_event;
+    duss_event_ack_identify_t wait_ack_list[32];
+    uint32_t wait_ack_cnt;
+    _Bool finish;
+    undefined field11_0x29d;
+    undefined field12_0x29e;
+    undefined field13_0x29f;
+    duss_event_cmd_desc_t *cmd_desc_tbl[79];
+    uint32_t cmd_desc_num[79];
+    void *userdata;
+};
+
+struct MpegEncContext
+{
+};
+
+struct AVPacketList
+{
+    struct AVPacket pkt;
+    struct AVPacketList *next;
+    undefined field2_0x5c;
+    undefined field3_0x5d;
+    undefined field4_0x5e;
+    undefined field5_0x5f;
+};
+
+struct AVProbeData
+{
+    char *filename;
+    uchar *buf;
+    int buf_size;
+    char *mime_type;
+};
+
+struct AVStream
+{
+    int index;
+    int id;
+    struct AVCodecContext *codec;
+    void *priv_data;
+    struct AVFrac pts;
+    struct AVRational time_base;
+    int64_t start_time;
+    int64_t duration;
+    int64_t nb_frames;
+    int disposition;
+    enum AVDiscard discard;
+    struct AVRational sample_aspect_ratio;
+    struct AVDictionary *metadata;
+    struct AVRational avg_frame_rate;
+    undefined field14_0x64;
+    undefined field15_0x65;
+    undefined field16_0x66;
+    undefined field17_0x67;
+    struct AVPacket attached_pic;
+    struct AVPacketSideData *side_data;
+    int nb_side_data;
+    int event_flags;
+    struct anon_struct_conflict69b3c_for_info *info;
+    int pts_wrap_bits;
+    undefined field24_0xd4;
+    undefined field25_0xd5;
+    undefined field26_0xd6;
+    undefined field27_0xd7;
+    int64_t first_dts;
+    int64_t cur_dts;
+    int64_t last_IP_pts;
+    int last_IP_duration;
+    int probe_packets;
+    int codec_info_nb_frames;
+    enum AVStreamParseType need_parsing;
+    struct AVCodecParserContext *parser;
+    struct AVPacketList *last_in_packet_buffer;
+    struct AVProbeData probe_data;
+    int64_t pts_buffer[17];
+    struct AVIndexEntry *index_entries;
+    int nb_index_entries;
+    uint index_entries_allocated_size;
+    struct AVRational r_frame_rate;
+    int stream_identifier;
+    int64_t interleaver_chunk_size;
+    int64_t interleaver_chunk_duration;
+    int request_probe;
+    int skip_to_keyframe;
+    int skip_samples;
+    undefined field49_0x1d4;
+    undefined field50_0x1d5;
+    undefined field51_0x1d6;
+    undefined field52_0x1d7;
+    int64_t first_discard_sample;
+    int64_t last_discard_sample;
+    int nb_decoded_frames;
+    undefined field56_0x1ec;
+    undefined field57_0x1ed;
+    undefined field58_0x1ee;
+    undefined field59_0x1ef;
+    int64_t mux_ts_offset;
+    int64_t pts_wrap_reference;
+    int pts_wrap_behavior;
+    int update_initial_durations_done;
+    int64_t pts_reorder_error[17];
+    uint8_t pts_reorder_error_count[17];
+    undefined field66_0x2a1;
+    undefined field67_0x2a2;
+    undefined field68_0x2a3;
+    undefined field69_0x2a4;
+    undefined field70_0x2a5;
+    undefined field71_0x2a6;
+    undefined field72_0x2a7;
+    int64_t last_dts_for_order_check;
+    uint8_t dts_ordered;
+    uint8_t dts_misordered;
+    undefined field76_0x2b2;
+    undefined field77_0x2b3;
+    int inject_global_side_data;
+    char *recommended_encoder_configuration;
+    struct AVRational display_aspect_ratio;
+    undefined field81_0x2c4;
+    undefined field82_0x2c5;
+    undefined field83_0x2c6;
+    undefined field84_0x2c7;
+};
+
+struct duss_hal_mem_buf
+{
+};
+
+struct AVSubtitleRect
+{
+    int x;
+    int y;
+    int w;
+    int h;
+    int nb_colors;
+    struct AVPicture pict;
+    enum AVSubtitleType type;
+    char *text;
+    char *ass;
+    int flags;
+};
+
+struct AVIOContext
+{
+    struct AVClass *av_class;
+    uchar *buffer;
+    int buffer_size;
+    uchar *buf_ptr;
+    uchar *buf_end;
+    void *opaque;
+    int (*read_packet)(void *, uint8_t *, int);
+    int (*write_packet)(void *, uint8_t *, int);
+    int64_t (*seek)(void *, int64_t, int);
+    undefined field9_0x24;
+    undefined field10_0x25;
+    undefined field11_0x26;
+    undefined field12_0x27;
+    int64_t pos;
+    int must_flush;
+    int eof_reached;
+    int write_flag;
+    int max_packet_size;
+    ulong checksum;
+    uchar *checksum_ptr;
+    ulong (*update_checksum)(ulong, uint8_t *, uint);
+    int error;
+    int (*read_pause)(void *, int);
+    int64_t (*read_seek)(void *, int, int64_t, int);
+    int seekable;
+    undefined field25_0x5c;
+    undefined field26_0x5d;
+    undefined field27_0x5e;
+    undefined field28_0x5f;
+    int64_t maxsize;
+    int direct;
+    undefined field31_0x6c;
+    undefined field32_0x6d;
+    undefined field33_0x6e;
+    undefined field34_0x6f;
+    int64_t bytes_read;
+    int seek_count;
+    int writeout_count;
+    int orig_buffer_size;
+    undefined field39_0x84;
+    undefined field40_0x85;
+    undefined field41_0x86;
+    undefined field42_0x87;
+};
+
+struct AVOption
 {
     char *name;
-    int32_t init_cnt;
+    char *help;
+    int offset;
+    enum AVOptionType type;
+    union anon_union_conflictac8f4_for_default_val default_val;
+    double min;
+    double max;
+    int flags;
+    char *unit;
 };
 
-struct anon_struct_conflict1d6ff3
+struct AVSubtitle
 {
-    struct duss_osal_sema_attrib_t attrib;
-    struct sem_t sema;
+    uint16_t format;
+    undefined field1_0x2;
+    undefined field2_0x3;
+    uint32_t start_display_time;
+    uint32_t end_display_time;
+    uint num_rects;
+    struct AVSubtitleRect **rects;
+    undefined field7_0x14;
+    undefined field8_0x15;
+    undefined field9_0x16;
+    undefined field10_0x17;
+    int64_t pts;
 };
 
-typedef struct anon_struct_conflict5d6 anon_struct_conflict5d6;
-
-struct anon_struct_conflict5d6
+struct duss_osal_task_handle_t
 {
     struct duss_osal_task_attrib_t attrib;
     pthread_t thread;
 };
 
-typedef struct anon_struct_conflict674 anon_struct_conflict674;
+struct modem_shmem_info_t
+{
+    uint32_t frm_idx;
+    uint16_t frm_isI;
+    uint16_t frm_len;
+    uint16_t frm_dsti;
+    uint16_t frm_dstf;
+    uint16_t channel_status;
+    uint16_t dec_err_status;
+    uint16_t cur_time;
+    uint16_t delta_time;
+    uint16_t dbg_msc;
+    uint8_t dbg_ap_ready;
+    uint8_t dbg_cp_ready;
+    uint32_t local_id;
+    uint8_t cp_state;
+    uint8_t cp_report;
+    uint8_t cp_report_seq;
+    uint8_t client_type;
+    uint32_t cp_boot_status0;
+    uint32_t cp_boot_status1;
+    uint32_t board_version;
+    uint32_t board_sub_version;
+    uint8_t machine_role;
+    uint8_t is_reverse;
+    int8_t cp_tx_power;
+    uint8_t gnd_type;
+    uint32_t cp_sssfn;
+    uint32_t ulow_en;
+    uint8_t mipi_rx_response;
+    uint8_t liveview_broken_status;
+    uint8_t reserved01;
+    uint8_t reserved02;
+    uint8_t ap_reboot_flag;
+    uint8_t ap_reboot_ack_flag;
+    uint8_t secure_sync_flag;
+    uint8_t reserve00;
+    uint8_t area_state;
+    uint8_t area_substate;
+    uint8_t GsCtrl;
+    uint8_t GsSubState;
+    uint8_t WaterLevel[4];
+    uint16_t RxCntStastic[4];
+    uint16_t TxCntStastic[4];
+    uint8_t Reserved[8];
+    uint32_t com_uart_status;
+    uint32_t fcr_rx_status;
+    uint32_t fcr_tx_status;
+    uint32_t frm_idx_for_display;
+    uint32_t frm_delay_for_display;
+    uint16_t wifi_sdr_mode;
+    uint16_t frm_isI_for_display;
+    uint32_t country_code;
+    uint16_t frm_len_for_display;
+    uint16_t delta_time_for_display;
+    uint8_t uint8_t_reboot_reason;
+    undefined field54_0x85;
+    undefined field55_0x86;
+    undefined field56_0x87;
+    uint64_t cpa7_version;
+    uint64_t dsp_version;
+    uint8_t u8_dual_band_capability;
+    undefined field60_0x99;
+    undefined field61_0x9a;
+    undefined field62_0x9b;
+    undefined field63_0x9c;
+    undefined field64_0x9d;
+    undefined field65_0x9e;
+    undefined field66_0x9f;
+};
 
-typedef struct duss_osal_timer_attrib_t duss_osal_timer_attrib_t;
+struct sqlite3
+{
+};
 
-typedef struct timespec timespec;
+struct cp_vdec
+{
+    void *gs_info;
+    uint32_t width;
+    uint32_t height;
+    void *cb_ctx;
+    int (*cb_func)(void *, dec_event_t);
+    vdec_state_t vdec_state;
+    _Bool b_running;
+    _Bool b_eos;
+    _Bool b_first_frm_sent;
+    undefined field9_0x1b;
+    gs_media_cmd_chnl_t *mcc;
+    int dmi_data_fd;
+    struct duss_osal_task_handle_t *thread_tx;
+    int frames_received;
+    int frames_sent;
+    struct duss_osal_mutex_handle_t *list_mutex;
+    struct duss_list_head frame_list;
+    int num_in_list;
+    int64_t play_tm_ms;
+};
 
-typedef void (*duss_osal_timer_entry_t)(void *);
-
-typedef __kernel_long_t __kernel_time_t;
-
-struct duss_osal_timer_attrib_t
+struct AVOutputFormat
 {
     char *name;
-    duss_osal_timer_entry_t entry;
-    void *param;
-    uint32_t timeout_us;
-    int32_t repeat_times;
-    enum duss_osal_priority_t priority;
+    char *long_name;
+    char *mime_type;
+    char *extensions;
+    enum AVCodecID audio_codec;
+    enum AVCodecID video_codec;
+    enum AVCodecID subtitle_codec;
+    int flags;
+    struct AVCodecTag **codec_tag;
+    struct AVClass *priv_class;
+    struct AVOutputFormat *next;
+    int priv_data_size;
+    int (*write_header)(struct AVFormatContext *);
+    int (*write_packet)(struct AVFormatContext *, struct AVPacket *);
+    int (*write_trailer)(struct AVFormatContext *);
+    int (*interleave_packet)(struct AVFormatContext *, struct AVPacket *, struct AVPacket *, int);
+    int (*query_codec)(enum AVCodecID, int);
+    void (*get_output_timestamp)(struct AVFormatContext *, int, int64_t *, int64_t *);
+    int (*control_message)(struct AVFormatContext *, int, void *, size_t);
+    int (*write_uncoded_frame)(struct AVFormatContext *, int, struct AVFrame **, uint);
+    int (*get_device_list)(struct AVFormatContext *, struct AVDeviceInfoList *);
+    int (*create_device_capabilities)(struct AVFormatContext *, struct AVDeviceCapabilitiesQuery *);
+    int (*free_device_capabilities)(struct AVFormatContext *, struct AVDeviceCapabilitiesQuery *);
 };
 
-struct timespec
+struct rc_set_function_pack_t
 {
-    __kernel_time_t tv_sec;
-    long tv_nsec;
+    uint8_t arm_channel : 2;
+    uint8_t arm_setval : 2;
+    uint8_t flip_channel : 2;
+    uint8_t flip_setval : 2;
 };
 
-struct anon_struct_conflict674
+struct pl_muxer_t
 {
-    struct duss_osal_timer_attrib_t attrib;
-    pthread_t thread;
-    int32_t repeat_cnt;
-    _Bool suspend;
-    _Bool restart;
-    undefined field5_0x22;
-    undefined field6_0x23;
-    struct sem_t sema;
-    struct sem_t lock;
-    struct timespec saved_time;
+    struct pl_muxer_itf_t *itf;
+    void *context;
+    void *me;
 };
 
-typedef struct anon_struct_conflict70e anon_struct_conflict70e;
-
-struct anon_struct_conflict70e
-{
-    struct duss_osal_mutex_attrib_t attrib;
-    struct sem_t sema;
-};
-
-typedef struct anon_struct_conflict767 anon_struct_conflict767;
-
-typedef struct duss_osal_event_attrib_t duss_osal_event_attrib_t;
-
-
-struct pthread_mutex_t
-{
-    int32_t __private[1];
-};
-
-struct pthread_cond_t
-{
-    int32_t __private[1];
-};
-
-struct duss_osal_event_attrib_t
+struct AVCodec
 {
     char *name;
+    char *long_name;
+    enum AVMediaType type;
+    enum AVCodecID id;
+    int capabilities;
+    struct AVRational *supported_framerates;
+    enum AVPixelFormat *pix_fmts;
+    int *supported_samplerates;
+    enum AVSampleFormat *sample_fmts;
+    uint64_t *channel_layouts;
+    uint8_t max_lowres;
+    undefined field11_0x29;
+    undefined field12_0x2a;
+    undefined field13_0x2b;
+    struct AVClass *priv_class;
+    struct AVProfile *profiles;
+    int priv_data_size;
+    struct AVCodec *next;
+    int (*init_thread_copy)(struct AVCodecContext *);
+    int (*update_thread_context)(struct AVCodecContext *, struct AVCodecContext *);
+    struct AVCodecDefault *defaults;
+    void (*init_static_data)(struct AVCodec *);
+    int (*init)(struct AVCodecContext *);
+    int (*encode_sub)(struct AVCodecContext *, uint8_t *, int, struct AVSubtitle *);
+    int (*encode2)(struct AVCodecContext *, struct AVPacket *, struct AVFrame *, int *);
+    int (*decode)(struct AVCodecContext *, void *, int *, struct AVPacket *);
+    int (*close)(struct AVCodecContext *);
+    void (*flush)(struct AVCodecContext *);
 };
 
-struct anon_struct_conflict767
+struct snd_pcm_mmap_control
 {
-    struct duss_osal_event_attrib_t attrib;
-    struct pthread_mutex_t mutex;
-    struct pthread_cond_t cond;
-    uint32_t data;
-    int32_t flag;
-};
-
-typedef struct anon_struct_conflict7f4 anon_struct_conflict7f4;
-
-typedef struct duss_osal_msgq_attrib_t duss_osal_msgq_attrib_t;
-
-struct duss_osal_msgq_attrib_t
-{
-    char *name;
-    uint32_t buf_size;
-};
-
-struct anon_struct_conflict7f4
-{
-    struct duss_osal_msgq_attrib_t attrib;
-    struct pthread_mutex_t r_mutex;
-    struct pthread_mutex_t s_mutex;
-    struct pthread_cond_t r_cond;
-    struct pthread_cond_t s_cond;
-    uint32_t buf_size;
-    uint32_t head;
-    uint32_t tail;
-    uint8_t *buffer;
-};
-
-typedef struct duss_osal_event_handle_t duss_osal_event_handle_t;
-
-struct duss_osal_event_handle_t
-{
-    struct duss_osal_event_attrib_t attrib;
-    struct pthread_mutex_t mutex;
-    struct pthread_cond_t cond;
-    uint32_t data;
-    int32_t flag;
-};
-
-typedef enum duss_osal_event_mode_t
-{
-    DUSS_OSAL_EVENT_MATCHALL = 1,
-    DUSS_OSAL_EVENT_AUTOCLEAR = 2
-} duss_osal_event_mode_t;
-
-typedef struct duss_osal_msgq_handle_t duss_osal_msgq_handle_t;
-
-struct duss_osal_msgq_handle_t
-{
-    struct duss_osal_msgq_attrib_t attrib;
-    struct pthread_mutex_t r_mutex;
-    struct pthread_mutex_t s_mutex;
-    struct pthread_cond_t r_cond;
-    struct pthread_cond_t s_cond;
-    uint32_t buf_size;
-    uint32_t head;
-    uint32_t tail;
-    uint8_t *buffer;
-};
-
-typedef struct duss_osal_sema_handle_t duss_osal_sema_handle_t;
-
-struct duss_osal_sema_handle_t
-{
-    struct duss_osal_sema_attrib_t attrib;
-    struct sem_t sema;
-};
-
-typedef struct duss_osal_timer_handle_t duss_osal_timer_handle_t;
-
-struct duss_osal_timer_handle_t
-{
-    struct duss_osal_timer_attrib_t attrib;
-    pthread_t thread;
-    int32_t repeat_cnt;
-    _Bool suspend;
-    _Bool restart;
-    undefined field5_0x22;
-    undefined field6_0x23;
-    struct sem_t sema;
-    struct sem_t lock;
-    struct timespec saved_time;
 };

--- a/jni/rec/rec_util.c
+++ b/jni/rec/rec_util.c
@@ -1,0 +1,19 @@
+#include "rec_util.h"
+#include <string.h>
+
+void rec_util_osd_path_from_video_path(const char *video_path, char *osd_path, size_t osd_path_size)
+{
+    char *file_basename = strrchr(video_path, '/') + 1;
+    char *file_ext = strrchr(file_basename, '.');
+    uint8_t file_dir_len = file_basename - video_path - 1;
+    uint8_t file_stem_len = file_ext - file_basename;
+
+    snprintf(
+        osd_path,
+        osd_path_size,
+        "%.*s/%.*s.osd",
+        file_dir_len,
+        video_path,
+        file_stem_len,
+        file_basename);
+}

--- a/jni/rec/rec_util.h
+++ b/jni/rec/rec_util.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <stdlib.h>
+
+void rec_util_osd_path_from_video_path(const char *video_path, char *osd_path, size_t osd_path_size);


### PR DESCRIPTION
Let's get this PR up as a draft since it's nearly done!

Roughly:
- Further hook `duss_osal_task_create` to grab `player_thread` and `vdec_thread` to steal contexts. These have the state (i.e., pause status, current playback time, etc.) we need. These threads get recreated every time a new file gets played.
- When playback is detected (i.e., thread contexts are created and indicate playing), try load the matching OSD files, fonts, etc., etc., then bust out into a playback-specific loop for the duration.
- In that new loop, tick through frames, etc., etc., rendering them as if they were regular OSD frames.
- Undo all of the above when playback stops.

Pausing and seeking works as you would expect. Frame timing is eh... since it only updates `frames_sent`, `play_tm_ms`, etc. when it sends new frames, which it does in chunks as the RTOS needs it, but good enough for emergency viewing. The RTOS itself is handling putting out frames.

Gated under `rec_pb_enabled` just like recording since it feels sketchy enough, still.

Main thing I'm thinking about at this stage is, if I should integrate it into the main event loop instead --- like I don't know what happens if you try to playback DVR yet while you've got a live feed coming in. I guess we still want to be processing them? Need to pass out some builds for early testing, too.
