### PR TITLE
Add FC blackbox integration

### DIFF
--- a/ipk/airunit/data/opt/bin/airunit-osd-start.sh
+++ b/ipk/airunit/data/opt/bin/airunit-osd-start.sh
@@ -12,3 +12,18 @@ echo $! > /opt/var/run/airunit-osd-dji.pid
 setprop dji.hdvt_uav_service 1
 setprop dji.shuttle_service 1
 
+
+
+BBSTORE="/blackbox/dump_tty_`date '+%Y%m%d-%H%M%S'`.log"
+
+stdbuf -o0 cat /dev/ttyS1_moved >$BBSTORE &
+echo $! > /opt/var/run/dump-tty.pid
+
+###wait 10sec and if file >0kb then kill process (msp data, not bb log)
+sleep 10
+if [ -s $BBSTORE ]; then
+	kill `cat /opt/var/run/dump-tty.pid`
+	rm $BBSTORE
+else
+	#file is empty = no msp data
+fi


### PR DESCRIPTION
Extra function for some FC not have on board storage/tf card and don't want to buy open lager
It will dump the serial port data to file depend on FC setting (by checking the "/blackbox/dump_tty_`date '+%Y%m%d-%H%M%S'`.log", file should be 0KB before ARM)

- when MSP is enable at betaflight, will stop dump serial port data and remove file
- when serial port set for "blackbox logging", serial data will save at "/blackbox/dump_tty_`date '+%Y%m%d-%H%M%S'`.log"

enable "Fast serial" and disable some blackbox headers to save logging overhead
example for filter tuning :
blackbox_disable_bat = ON
blackbox_disable_mag = ON
blackbox_disable_alt = ON
blackbox_disable_rssi = ON
blackbox_disable_acc = ON
blackbox_disable_gps = ON

blackbox_disable_pids = ON
blackbox_disable_rc = ON
blackbox_disable_setpoint = OFF
blackbox_disable_gyro = OFF
blackbox_disable_debug = OFF
blackbox_disable_motors = ON

blackbox_sample_rate = 1/4
blackbox_device = SERIAL
serial 1 128 230400 57600 0 230400

example blackbox log by airunit :
https://drive.google.com/file/d/1P9ec8A5KaPk-B-X7xyCkKzkZl2Nvf1eA/view?usp=share_link