### PR TITLE
Change framebuffer handling to avoid the reboot

### DIFF
--- a/ipk/goggle/control/control
+++ b/ipk/goggle/control/control
@@ -1,5 +1,5 @@
 Package: msp-osd
-Version: 0.10.1
+Version: 0.11.0
 Maintainer: bri3d
 Description: MSP OSD service for the DJI HD FPV goggles.
 Architecture: pigeon-glasses

--- a/jni/fakehd/fakehd.h
+++ b/jni/fakehd/fakehd.h
@@ -1,3 +1,5 @@
+#pragma once
+
 void load_fakehd_config();
 void fakehd_disable();
 void fakehd_enable();

--- a/jni/hw/dji_display.c
+++ b/jni/hw/dji_display.c
@@ -1,10 +1,13 @@
 #include <stdlib.h>
 #include "dji_display.h"
+#include "util/debug.h"
 
 #define GOGGLES_V1_VOFFSET 575
 #define GOGGLES_V2_VOFFSET 215
 
 static duss_result_t pop_func(duss_disp_instance_handle_t *disp_handle,duss_disp_plane_id_t plane_id, duss_frame_buffer_t *frame_buffer,void *user_ctx) {
+    dji_display_state_t *display_state = (dji_display_state_t *)user_ctx;
+    display_state->frame_waiting = 0;
     return 0;
 }
 
@@ -15,6 +18,7 @@ dji_display_state_t *dji_display_state_alloc(uint8_t is_v2_goggles) {
     display_state->fb_1 = (duss_frame_buffer_t *)calloc(1,sizeof(duss_frame_buffer_t));
     display_state->pb_0 = (duss_disp_plane_blending_t *)calloc(1, sizeof(duss_disp_plane_blending_t));
     display_state->is_v2_goggles = is_v2_goggles;
+    display_state->frame_waiting = 0;
     return display_state;
 }
 
@@ -27,7 +31,6 @@ void dji_display_state_free(dji_display_state_t *display_state) {
 }
 
 void dji_display_close_framebuffer(dji_display_state_t *display_state) {
- 
     duss_hal_display_port_enable(display_state->disp_instance_handle, 3, 0);
     duss_hal_display_release_plane(display_state->disp_instance_handle, display_state->plane_id);
     duss_hal_display_close(display_state->disp_handle, &display_state->disp_instance_handle);
@@ -94,7 +97,7 @@ void dji_display_open_framebuffer(dji_display_state_t *display_state, duss_disp_
         printf("failed to acquire plane");
         exit(0);
     }
-    res = duss_hal_display_register_frame_cycle_callback(display_state->disp_instance_handle, plane_id, &pop_func, 0);
+    res = duss_hal_display_register_frame_cycle_callback(display_state->disp_instance_handle, plane_id, &pop_func, display_state);
     if (res != 0) {
         printf("failed to register callback");
         exit(0);
@@ -171,10 +174,117 @@ void dji_display_open_framebuffer(dji_display_state_t *display_state, duss_disp_
     }
 }
 
+
+void dji_display_open_framebuffer_injected(dji_display_state_t *display_state, duss_disp_instance_handle_t *disp, duss_hal_obj_handle_t ion_handle, duss_disp_plane_id_t plane_id) {
+    uint32_t hal_device_open_unk = 0;
+    duss_result_t res = 0;
+    display_state->disp_instance_handle = disp;
+    display_state->ion_handle = ion_handle;
+    display_state->plane_id = plane_id;
+
+    // PLANE BLENDING
+
+    display_state->pb_0->is_enable = 1;
+
+    // TODO just check hwid to figure this out. Not actually V1/V2 related but an HW version ID.
+
+    display_state->pb_0->voffset = GOGGLES_V1_VOFFSET;
+    display_state->pb_0->hoffset = 0;
+
+    // On Goggles V1, the UI and video are in Z-Order 1. On Goggles V2, they're in Z-Order 4.
+    // Unfortunately, this means we cannot draw below the DJI UI on Goggles V1. But, on Goggles V2 we get what we want.
+
+    display_state->pb_0->order = 2;
+
+    // Global alpha - disable as we want per pixel alpha.
+
+    display_state->pb_0->glb_alpha_en = 0;
+    display_state->pb_0->glb_alpha_val = 0;
+
+    // These aren't documented. Blending algorithm 0 is employed for menus and 1 for screensaver.
+
+    display_state->pb_0->blending_alg = 1;
+
+    // No idea what this "plane mode" actually does but it's different on V2
+    uint8_t acquire_plane_mode = display_state->is_v2_goggles ? 6 : 0;
+
+    DEBUG_PRINT("acquire plane\n");
+    res = duss_hal_display_aquire_plane(display_state->disp_instance_handle,acquire_plane_mode,&plane_id);
+    if (res != 0) {
+        DEBUG_PRINT("failed to acquire plane");
+        exit(0);
+    }
+    res = duss_hal_display_register_frame_cycle_callback(display_state->disp_instance_handle, plane_id, &pop_func, 0);
+    if (res != 0) {
+        DEBUG_PRINT("failed to register callback");
+        exit(0);
+    }
+
+    res = duss_hal_display_plane_blending_set(display_state->disp_instance_handle, plane_id, display_state->pb_0);
+
+    if (res != 0) {
+        DEBUG_PRINT("failed to set blending");
+        exit(0);
+    }
+    DEBUG_PRINT("alloc ion buf\n");
+    res = duss_hal_mem_alloc(display_state->ion_handle,&display_state->ion_buf_0,0x473100,0x400,0,0x17);
+    if (res != 0) {
+        DEBUG_PRINT("failed to allocate VRAM");
+        exit(0);
+    }
+    res = duss_hal_mem_map(display_state->ion_buf_0, &display_state->fb0_virtual_addr);
+    if (res != 0) {
+        DEBUG_PRINT("failed to map VRAM");
+        exit(0);
+    }
+    res = duss_hal_mem_get_phys_addr(display_state->ion_buf_0, &display_state->fb0_physical_addr);
+    if (res != 0) {
+        DEBUG_PRINT("failed to get FB0 phys addr");
+        exit(0);
+    }
+    DEBUG_PRINT("first buffer VRAM mapped virtual memory is at %p : %p\n", display_state->fb0_virtual_addr, display_state->fb0_physical_addr);
+
+    res = duss_hal_mem_alloc(display_state->ion_handle,&display_state->ion_buf_1,0x473100,0x400,0,0x17);
+    if (res != 0) {
+        DEBUG_PRINT("failed to allocate FB1 VRAM");
+        exit(0);
+    }
+    res = duss_hal_mem_map(display_state->ion_buf_1,&display_state->fb1_virtual_addr);
+    if (res != 0) {
+        DEBUG_PRINT("failed to map FB1 VRAM");
+        exit(0);
+    }
+    res = duss_hal_mem_get_phys_addr(display_state->ion_buf_1, &display_state->fb1_physical_addr);
+    if (res != 0) {
+        DEBUG_PRINT("failed to get FB1 phys addr");
+        exit(0);
+    }
+    DEBUG_PRINT("second buffer VRAM mapped virtual memory is at %p : %p\n", display_state->fb1_virtual_addr, display_state->fb1_physical_addr);
+
+    for(int i = 0; i < 2; i++) {
+        duss_frame_buffer_t *fb = i ? display_state->fb_1 : display_state->fb_0;
+        fb->buffer = i ? display_state->ion_buf_1 : display_state->ion_buf_0;
+        fb->pixel_format = display_state->is_v2_goggles ? DUSS_PIXFMT_RGBA8888_GOGGLES_V2 : DUSS_PIXFMT_RGBA8888; // 20012 instead on V2
+        fb->frame_id = i;
+        fb->planes[0].bytes_per_line = 0x1680;
+        fb->planes[0].offset = 0;
+        fb->planes[0].plane_height = 810;
+        fb->planes[0].bytes_written = 0x473100;
+        fb->width = 1440;
+        fb->height = 810;
+        fb->plane_count = 1;
+    }
+}
+
 void dji_display_push_frame(dji_display_state_t *display_state, uint8_t which_fb) {
     duss_frame_buffer_t *fb = which_fb ? display_state->fb_1 : display_state->fb_0;
     duss_hal_mem_sync(fb->buffer, 1);
-    duss_hal_display_push_frame(display_state->disp_instance_handle, display_state->plane_id, fb);
+    if (display_state->frame_waiting == 0) {
+        display_state->frame_waiting = 1;
+        duss_hal_display_push_frame(display_state->disp_instance_handle, display_state->plane_id, fb);
+    } else {
+        DEBUG_PRINT("!!! Dropped frame due to pending frame push!\n");
+    }
 }
 
 void *dji_display_get_fb_address(dji_display_state_t *display_state, uint8_t which_fb) {

--- a/jni/hw/dji_display.c
+++ b/jni/hw/dji_display.c
@@ -5,13 +5,6 @@
 #define GOGGLES_V1_VOFFSET 575
 #define GOGGLES_V2_VOFFSET 215
 
-static duss_result_t pop_func(duss_disp_instance_handle_t *disp_handle,duss_disp_plane_id_t plane_id, duss_frame_buffer_t *frame_buffer,void *user_ctx) {
-    dji_display_state_t *display_state = (dji_display_state_t *)user_ctx;
-    display_state->frame_drawn = 0;
-    printf("fbdebug pop_func\n");
-    return 0;
-}
-
 dji_display_state_t *dji_display_state_alloc(uint8_t is_v2_goggles) {
     dji_display_state_t *display_state = calloc(1, sizeof(dji_display_state_t));
     display_state->disp_instance_handle = (duss_disp_instance_handle_t *)calloc(1, sizeof(duss_disp_instance_handle_t));
@@ -96,11 +89,6 @@ void dji_display_open_framebuffer(dji_display_state_t *display_state, duss_disp_
     res = duss_hal_display_aquire_plane(display_state->disp_instance_handle,acquire_plane_mode,&plane_id);
     if (res != 0) {
         printf("failed to acquire plane");
-        exit(0);
-    }
-    res = duss_hal_display_register_frame_cycle_callback(display_state->disp_instance_handle, plane_id, &pop_func, display_state);
-    if (res != 0) {
-        printf("failed to register callback");
         exit(0);
     }
     res = duss_hal_display_port_enable(display_state->disp_instance_handle, 3, 1);
@@ -213,11 +201,6 @@ void dji_display_open_framebuffer_injected(dji_display_state_t *display_state, d
     res = duss_hal_display_aquire_plane(display_state->disp_instance_handle,acquire_plane_mode,&plane_id);
     if (res != 0) {
         DEBUG_PRINT("failed to acquire plane");
-        exit(0);
-    }
-    res = duss_hal_display_register_frame_cycle_callback(display_state->disp_instance_handle, plane_id, &pop_func, 0);
-    if (res != 0) {
-        DEBUG_PRINT("failed to register callback");
         exit(0);
     }
 

--- a/jni/hw/dji_display.c
+++ b/jni/hw/dji_display.c
@@ -276,14 +276,16 @@ void dji_display_open_framebuffer_injected(dji_display_state_t *display_state, d
     }
 }
 
-void dji_display_push_frame(dji_display_state_t *display_state, uint8_t which_fb) {
+uint8_t dji_display_push_frame(dji_display_state_t *display_state, uint8_t which_fb) {
     duss_frame_buffer_t *fb = which_fb ? display_state->fb_1 : display_state->fb_0;
     duss_hal_mem_sync(fb->buffer, 1);
     if (display_state->frame_waiting == 0) {
         display_state->frame_waiting = 1;
         duss_hal_display_push_frame(display_state->disp_instance_handle, display_state->plane_id, fb);
+        return !which_fb;
     } else {
         DEBUG_PRINT("!!! Dropped frame due to pending frame push!\n");
+        return which_fb;
     }
 }
 

--- a/jni/hw/dji_display.h
+++ b/jni/hw/dji_display.h
@@ -20,7 +20,7 @@ typedef struct dji_display_state_s {
     uint8_t frame_waiting;
 } dji_display_state_t;
 
-void dji_display_push_frame(dji_display_state_t *display_state, uint8_t which_fb);
+uint8_t dji_display_push_frame(dji_display_state_t *display_state, uint8_t which_fb);
 void dji_display_open_framebuffer(dji_display_state_t *display_state, duss_disp_plane_id_t plane_id);
 void dji_display_open_framebuffer_injected(dji_display_state_t *display_state, duss_disp_instance_handle_t *disp, duss_hal_obj_handle_t ion_handle, duss_disp_plane_id_t plane_id);
 void dji_display_close_framebuffer(dji_display_state_t *display_state);

--- a/jni/hw/dji_display.h
+++ b/jni/hw/dji_display.h
@@ -20,10 +20,10 @@ typedef struct dji_display_state_s {
     uint8_t frame_waiting;
 } dji_display_state_t;
 
-uint8_t dji_display_push_frame(dji_display_state_t *display_state, uint8_t which_fb);
+void dji_display_push_frame(dji_display_state_t *display_state);
 void dji_display_open_framebuffer(dji_display_state_t *display_state, duss_disp_plane_id_t plane_id);
 void dji_display_open_framebuffer_injected(dji_display_state_t *display_state, duss_disp_instance_handle_t *disp, duss_hal_obj_handle_t ion_handle, duss_disp_plane_id_t plane_id);
 void dji_display_close_framebuffer(dji_display_state_t *display_state);
 dji_display_state_t *dji_display_state_alloc(uint8_t is_v2_goggles);
 void dji_display_state_free(dji_display_state_t *display_state);
-void *dji_display_get_fb_address(dji_display_state_t *display_state, uint8_t which_fb);
+void *dji_display_get_fb_address(dji_display_state_t *display_state);

--- a/jni/hw/dji_display.h
+++ b/jni/hw/dji_display.h
@@ -17,7 +17,7 @@ typedef struct dji_display_state_s {
     duss_frame_buffer_t *fb_1;
     duss_disp_plane_blending_t *pb_0;
     uint8_t is_v2_goggles;
-    uint8_t frame_waiting;
+    uint8_t frame_drawn;
 } dji_display_state_t;
 
 void dji_display_push_frame(dji_display_state_t *display_state);

--- a/jni/hw/dji_display.h
+++ b/jni/hw/dji_display.h
@@ -1,5 +1,4 @@
-#ifndef DJI_DISPLAY_H
-#define DJI_DISPLAY_H
+#pragma once
 #include "duml_hal.h"
 
 typedef struct dji_display_state_s {
@@ -18,12 +17,13 @@ typedef struct dji_display_state_s {
     duss_frame_buffer_t *fb_1;
     duss_disp_plane_blending_t *pb_0;
     uint8_t is_v2_goggles;
+    uint8_t frame_waiting;
 } dji_display_state_t;
 
 void dji_display_push_frame(dji_display_state_t *display_state, uint8_t which_fb);
 void dji_display_open_framebuffer(dji_display_state_t *display_state, duss_disp_plane_id_t plane_id);
+void dji_display_open_framebuffer_injected(dji_display_state_t *display_state, duss_disp_instance_handle_t *disp, duss_hal_obj_handle_t ion_handle, duss_disp_plane_id_t plane_id);
 void dji_display_close_framebuffer(dji_display_state_t *display_state);
 dji_display_state_t *dji_display_state_alloc(uint8_t is_v2_goggles);
 void dji_display_state_free(dji_display_state_t *display_state);
 void *dji_display_get_fb_address(dji_display_state_t *display_state, uint8_t which_fb);
-#endif

--- a/jni/hw/dji_radio_shm.h
+++ b/jni/hw/dji_radio_shm.h
@@ -1,3 +1,5 @@
+
+#pragma once
 #include <stdint.h>
 
 #define RTOS_SHM_ADDRESS 0xfffc1000

--- a/jni/hw/dji_services.h
+++ b/jni/hw/dji_services.h
@@ -1,3 +1,5 @@
+#pragma once
+
 void dji_stop_goggles(int is_v2);
 void dji_start_goggles(int is_v2);
 int dji_goggles_are_v2();

--- a/jni/hw/duml_hal.h
+++ b/jni/hw/duml_hal.h
@@ -1,5 +1,4 @@
-#ifndef DUML_HAL_H
-#define DUML_HAL_H
+#pragma once
 #include <stdint.h>
 
 typedef int32_t duss_result_t;
@@ -259,4 +258,3 @@ duss_result_t duss_hal_attach_disp(char *param_1,duss_hal_obj **param_2);
 duss_result_t duss_hal_attach_ion_mem(char *param_1,duss_hal_obj **param_2);
 duss_result_t duss_hal_detach_ion_mem();
 duss_result_t duss_hal_detach_disp();
-#endif

--- a/jni/msp/msp.h
+++ b/jni/msp/msp.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <stdint.h>
 
 #define MSP_CMD_API_VERSION 1

--- a/jni/msp/msp_displayport.h
+++ b/jni/msp/msp_displayport.h
@@ -1,4 +1,6 @@
+#pragma once
 #include <stdint.h>
+#include "msp.h"
 
 typedef enum {
     MSP_DISPLAYPORT_KEEPALIVE,

--- a/jni/msp_displayport_mux.c
+++ b/jni/msp_displayport_mux.c
@@ -13,6 +13,7 @@
 #include "net/serial.h"
 #include "msp/msp.h"
 #include "msp/msp_displayport.h"
+#include "util/debug.h"
 #include "util/time_util.h"
 #include "util/fs_util.h"
 
@@ -41,12 +42,6 @@ enum {
 
 // The Betaflight MSP minor version in which MSP DisplayPort sizing is supported.
 #define MSP_DISPLAY_SIZE_VERSION 45
-
-#ifdef DEBUG
-#define DEBUG_PRINT(fmt, args...)    fprintf(stderr, fmt, ## args)
-#else
-#define DEBUG_PRINT(fmt, args...)
-#endif
 
 typedef struct msp_cache_entry_s {
     struct timespec time;

--- a/jni/net/network.h
+++ b/jni/net/network.h
@@ -1,2 +1,4 @@
+#pragma once
+
 int connect_to_server(char *address, int port);
 int bind_socket(int port);

--- a/jni/net/serial.h
+++ b/jni/net/serial.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <termios.h>
 
 int open_serial_port(const char *device, speed_t baudrate);

--- a/jni/osd.h
+++ b/jni/osd.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "hw/dji_display.h"
 
 void osd_directfb(duss_disp_instance_handle_t *disp, duss_hal_obj_handle_t ion_handle);

--- a/jni/osd_dji_overlay_udp.c
+++ b/jni/osd_dji_overlay_udp.c
@@ -188,7 +188,7 @@ static void draw_character_map(display_info_t *display_info, void* restrict fb_a
     for(int y = 0; y < display_info->char_height; y++) {
         for(int x = 0; x < display_info->char_width; x++) {
             uint16_t c = character_map[x][y];
-            // if (c != 0) {
+            if (c != 0) {
                 font = display_info->font_page_1;
                 if (c > 255) {
                     c = c & 0xFF;
@@ -210,7 +210,7 @@ static void draw_character_map(display_info_t *display_info, void* restrict fb_a
                     target_offset += WIDTH * BYTES_PER_PIXEL - (display_info->font_width * BYTES_PER_PIXEL);
                 }
                 // DEBUG_PRINT("%c", c > 31 ? c : 20);
-            // }
+            }
             // DEBUG_PRINT(" ");
         }
         // DEBUG_PRINT("\n");
@@ -226,7 +226,7 @@ static void clear_framebuffer() {
 static void draw_screen() {
     void *fb_addr = dji_display_get_fb_address(dji_display);
     // DJI has a backwards alpha channel - FF is transparent, 00 is opaque.
-    // memset(fb_addr, 0x000000FF, WIDTH * HEIGHT * BYTES_PER_PIXEL);
+    memset(fb_addr, 0x000000FF, WIDTH * HEIGHT * BYTES_PER_PIXEL);
 
     if (fakehd_is_enabled()) {
         fakehd_map_sd_character_map_to_hd(msp_character_map, msp_render_character_map);

--- a/jni/osd_dji_overlay_udp.c
+++ b/jni/osd_dji_overlay_udp.c
@@ -104,7 +104,6 @@ static uint16_t msp_character_map[MAX_DISPLAY_X][MAX_DISPLAY_Y];
 static uint16_t msp_render_character_map[MAX_DISPLAY_X][MAX_DISPLAY_Y];
 static uint16_t overlay_character_map[MAX_DISPLAY_X][MAX_DISPLAY_Y];
 static displayport_vtable_t *display_driver;
-static uint8_t which_fb = 0;
 struct timespec last_render;
 
 static char current_fc_variant[5];
@@ -189,7 +188,7 @@ static void draw_character_map(display_info_t *display_info, void* restrict fb_a
     for(int y = 0; y < display_info->char_height; y++) {
         for(int x = 0; x < display_info->char_width; x++) {
             uint16_t c = character_map[x][y];
-            if (c != 0) {
+            // if (c != 0) {
                 font = display_info->font_page_1;
                 if (c > 255) {
                     c = c & 0xFF;
@@ -211,7 +210,7 @@ static void draw_character_map(display_info_t *display_info, void* restrict fb_a
                     target_offset += WIDTH * BYTES_PER_PIXEL - (display_info->font_width * BYTES_PER_PIXEL);
                 }
                 // DEBUG_PRINT("%c", c > 31 ? c : 20);
-            }
+            // }
             // DEBUG_PRINT(" ");
         }
         // DEBUG_PRINT("\n");
@@ -219,15 +218,15 @@ static void draw_character_map(display_info_t *display_info, void* restrict fb_a
 }
 
 static void clear_framebuffer() {
-    void *fb_addr = dji_display_get_fb_address(dji_display, which_fb);
+    void *fb_addr = dji_display_get_fb_address(dji_display);
     // DJI has a backwards alpha channel - FF is transparent, 00 is opaque.
     memset(fb_addr, 0x000000FF, WIDTH * HEIGHT * BYTES_PER_PIXEL);
 }
 
 static void draw_screen() {
-    void *fb_addr = dji_display_get_fb_address(dji_display, which_fb);
+    void *fb_addr = dji_display_get_fb_address(dji_display);
     // DJI has a backwards alpha channel - FF is transparent, 00 is opaque.
-    memset(fb_addr, 0x000000FF, WIDTH * HEIGHT * BYTES_PER_PIXEL);
+    // memset(fb_addr, 0x000000FF, WIDTH * HEIGHT * BYTES_PER_PIXEL);
 
     if (fakehd_is_enabled()) {
         fakehd_map_sd_character_map_to_hd(msp_character_map, msp_render_character_map);
@@ -252,7 +251,7 @@ static void render_screen() {
     if (display_mode == DISPLAY_DISABLED) {
         clear_framebuffer();
     }
-    which_fb = dji_display_push_frame(dji_display, which_fb);
+    dji_display_push_frame(dji_display);
     DEBUG_PRINT("drew a frame\n");
     clock_gettime(CLOCK_MONOTONIC, &last_render);
 }

--- a/jni/osd_dji_overlay_udp.c
+++ b/jni/osd_dji_overlay_udp.c
@@ -252,8 +252,7 @@ static void render_screen() {
     if (display_mode == DISPLAY_DISABLED) {
         clear_framebuffer();
     }
-    dji_display_push_frame(dji_display, which_fb);
-    which_fb = !which_fb;
+    which_fb = dji_display_push_frame(dji_display, which_fb);
     DEBUG_PRINT("drew a frame\n");
     clock_gettime(CLOCK_MONOTONIC, &last_render);
 }

--- a/jni/osd_dji_udp.c
+++ b/jni/osd_dji_udp.c
@@ -22,6 +22,7 @@
 #include "net/data_protocol.h"
 #include "msp/msp.h"
 #include "msp/msp_displayport.h"
+#include "util/debug.h"
 #include "util/fs_util.h"
 
 #define MSP_PORT 7654
@@ -47,12 +48,6 @@
 #define EV_CODE_BACK 0xc9
 
 #define BACK_BUTTON_DELAY 4
-
-#ifdef DEBUG
-#define DEBUG_PRINT(fmt, args...)    fprintf(stderr, fmt, ## args)
-#else
-#define DEBUG_PRINT(fmt, args...)
-#endif
 
 #define SWAP32(data)   \
 ( (((data) >> 24) & 0x000000FF) | (((data) >>  8) & 0x0000FF00) | \

--- a/jni/osd_sfml_udp.c
+++ b/jni/osd_sfml_udp.c
@@ -16,12 +16,7 @@
 #include "msp/msp_displayport.h"
 #include "net/serial.h"
 #include "net/network.h"
-
-#ifdef DEBUG
-#define DEBUG_PRINT(fmt, args...)    fprintf(stderr, fmt, ## args)
-#else
-#define DEBUG_PRINT(fmt, args...)
-#endif
+#include "util/debug.h"
 
 #define X_OFFSET 120
 

--- a/jni/toast/toast.h
+++ b/jni/toast/toast.h
@@ -1,3 +1,5 @@
+#pragma once
+
 int toast(char*, ...);
 void toast_load_config();
 void do_toast(void (*display_print_string)(uint8_t init_x, uint8_t y, const char *string, uint8_t len));

--- a/jni/util/debug.h
+++ b/jni/util/debug.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#ifdef DEBUG
+#define DEBUG_PRINT(fmt, args...)    fprintf(stderr, fmt, ## args)
+#else
+#define DEBUG_PRINT(fmt, args...)
+#endif

--- a/jni/util/fs_util.c
+++ b/jni/util/fs_util.c
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <string.h>
+#include <stdlib.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 

--- a/jni/util/fs_util.h
+++ b/jni/util/fs_util.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <stdint.h>
 
 int32_t get_int_from_fs(char* path);

--- a/jni/util/time_util.h
+++ b/jni/util/time_util.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <time.h>
 #include <stdbool.h>
 


### PR DESCRIPTION
Pending some final test runs to confirm/validate existing test results.

Long run tests are suggesting that the change here to singlebuffering with memcpy from a backbuffer, instead of swapping the buffers avoids the occasional reboot. (single buffer works too - but it's hard to avoid flickers) 

We believe this brings some hypothetical risk of tearing type glitches, though we've yet to see it.